### PR TITLE
Independence

### DIFF
--- a/ControllerBase.py
+++ b/ControllerBase.py
@@ -71,7 +71,7 @@ class Controller(object):
             if not m:
                 continue
             resp = self.SendRecv(func(m))
-            if resp['retval']:
+            if resp['retcode']:
                 self.logger.error("Did not accept command '%s'" % command)
             return
         self.logger.error("Did not understand command '%s'" % command)

--- a/Doberman.py
+++ b/Doberman.py
@@ -4,13 +4,13 @@ import logging
 import DobermanDB
 import alarmDistribution
 import datetime
-from datetime.datetime import now as dtnow
 from argparse import ArgumentParser
 import DobermanLogging
 import Plugin
 import psutil
 from subprocess import Popen, PIPE, TimeoutExpired
 import serial
+dtnow = datetime.datetime.now
 
 __version__ = '2.0.0'
 
@@ -173,7 +173,7 @@ class Doberman(object):
             if not config['online']:
                 continue
             alarm_status = config['alarm_status'][config[name]['runmode']]
-            print('  %s: %s' : (name, alarm_status))
+            print('  %s: %s' % (name, alarm_status))
 
         print("\n--Contacts, status:")
         for contact in self.db.getContacts():
@@ -203,7 +203,7 @@ class Doberman(object):
     def checkCommands(self):
         collection = self.db._check('logging','commands')
         select = lambda : {'name' : 'doberman', 'acknowledged' : {'$exists' : 0},
-                'logged' : {'$leq' : dtnow()}}
+                'logged' : {'$lte' : dtnow()}}
         updates = lambda : {'$set' : {'acknowledged' : dtnow()}}
         while collection.count(select()):
             updates = {'$set' : {'acknowledged' : dtnow()}}
@@ -331,11 +331,11 @@ def main():
     if opts.version:
         print('Doberman version %s' % __version__)
         return
-    loglevel = DDB.getDefaultSettings(runmode = opts.runmode, name='loglevel')
+    loglevel = db.getDefaultSettings(runmode = opts.runmode, name='loglevel')
     logger.setLevel(int(loglevel))
 
     # Load and start script
-    doberman = Doberman(opts.runmode, opts.overlord, args.force)
+    doberman = Doberman(opts.runmode, opts.overlord, opts.force)
     try:
         if doberman.Start():
             logger.error('Something went wrong here...')

--- a/Doberman.py
+++ b/Doberman.py
@@ -210,8 +210,9 @@ class Doberman(object):
             if command == 'stop':
                 self.running = False
             elif command == 'restart':
-                self.close()
-                self.Start()
+                self.db.StoreCommand('all stop')
+                time.sleep(10)
+                self.startAllControllers()
             elif 'runmode' in command:
                 try:
                     _, runmode = command.split()

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -519,10 +519,20 @@ def main():
                         help='Add a new contact')
     parser.add_argument('--add-controller', default=None, type=str,
                         help='Specify a new controller config file to load')
+    parser.add_argument('--running', action='store_true', default=False,
+                        help='List currently running controllers')
     args = parser.parse_args()
     if args.command:
         db.StoreCommand(' '.join(args.command))
         print("Stored '%s'" % ' '.join(args.command))
+    if args.running:
+        cursor = db.readFromDatabase('settings','controllers',{'online' : True})
+        print('Currently running controllers:')
+        print('Name : Status : Runmode')
+        for row in cursor:
+            runmode = row['runmode']
+            status = row['status'][runmode]
+            print('  %s: %s : %s' % (row['name'], status, runmode)))
     try:
         if args.add_runmode:
             db.addOpmode()

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -141,9 +141,10 @@ class DobermanDB(object):
         controller, cmd = command.split(maxsplit=1)
         self.logger.debug(f"Storing command '{cmd}' for {controller}")
         if controller == 'all':
-            controller = self.Distinct('settings','controllers','name',{'online' : True})
+            coll = self._check('settings','controllers')
+            controllers = coll.distinct('name',{'online' : True})
         else:
-            controller = [controller]
+            controllers = [controller]
         for ctrl in controllers:
             if self.insertIntoDatabase('logging', 'commands',
                 {'name' : ctrl, 'command' : cmd, 'logged' : dtnow()}):

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 import logging
 import datetime
-from datetime.datetime import now as dtnow
 import pymongo
 import os.path
 import utils
 import argparse
+dtnow = datetime.datetime.now
 
 
 class DobermanDB(object):
@@ -524,7 +524,7 @@ def main():
         for row in cursor:
             runmode = row['runmode']
             status = row['status'][runmode]
-            print('  %s: %s : %s' % (row['name'], status, runmode)))
+            print('  %s: %s : %s' % (row['name'], status, runmode))
     try:
         if args.add_runmode:
             db.addOpmode()

--- a/DobermanLogging.py
+++ b/DobermanLogging.py
@@ -1,6 +1,6 @@
 import logging
 import logging.handlers
-from DobermanDB import DobermanDB
+import DobermanDB
 import datetime
 import os
 
@@ -12,7 +12,7 @@ class DobermanLogger(logging.Handler):
     """
     def __init__(self, stilltesting = True):
         logging.Handler.__init__(self)
-        self.db = DobermanDB()
+        self.db = DobermanDB.DobermanDB()
         self.db_name = 'logging'
         self.collection_name = 'logs'
         backup_filename = datetime.date.today().isoformat()
@@ -26,6 +26,9 @@ class DobermanLogger(logging.Handler):
                 '%(lineno)d | %(message)s')
         self.setFormatter(f)
         self.stream.setFormatter(f)
+
+    def __del__(self):
+        self.db.close()
 
     def emit(self, record):
         if record.levelno == logging.DEBUG or self.testing:

--- a/DobermanLogging.py
+++ b/DobermanLogging.py
@@ -10,7 +10,7 @@ class DobermanLogger(logging.Handler):
     Custom logging interface for Doberman. Gives us the option to log to
     the database (with disk as backup).
     """
-    def __init__(self, stilltesting = True):
+    def __init__(self, stilltesting = False):
         logging.Handler.__init__(self)
         self.db = DobermanDB()
         self.db_name = 'logging'

--- a/DobermanLogging.py
+++ b/DobermanLogging.py
@@ -10,7 +10,7 @@ class DobermanLogger(logging.Handler):
     Custom logging interface for Doberman. Gives us the option to log to
     the database (with disk as backup).
     """
-    def __init__(self, stilltesting = False):
+    def __init__(self, stilltesting = True):
         logging.Handler.__init__(self)
         self.db = DobermanDB()
         self.db_name = 'logging'
@@ -31,7 +31,7 @@ class DobermanLogger(logging.Handler):
         if record.levelno == logging.DEBUG or self.testing:
             self.emit_to_stdout(record)
             return
-        rec = dict(when     = record.asctime,
+        rec = dict(when     = datetime.datetime.fromtimestamp(record.created),
                 msg         = record.message,
                 level       = record.levelno,
                 name        = record.name,

--- a/ExampleController.py
+++ b/ExampleController.py
@@ -25,7 +25,7 @@ class ExampleController(SerialController):
         This function makes sure you connected to the correct controller
         """
         resp = self.SendRecv(self.commands['check_id'])
-        if resp['retval']:
+        if resp['retcode']:
             self.logger.error('An error')
             self._connected = False
             return -1
@@ -48,13 +48,13 @@ class ExampleController(SerialController):
         status = []
         for coms in ['read','also_read']:
             resp = self.SendRecv(self.commands[com])
-            if resp['retval']:
+            if resp['retcode']:
                 status.append(-1)
                 vals.append(-1)
             else:
                 status.append(0)
                 vals.append(float(resp['data']))
-        return {'retval' : status, 'data' : vals}
+        return {'retcode' : status, 'data' : vals}
 
     def ExecuteCommand(self, command):
         """
@@ -66,7 +66,7 @@ class ExampleController(SerialController):
         task, value = command.split()
         com = self.setcommand.format(cmd=self.commands[task],value=value)
         resp = self.SendRecv(com)
-        if resp['retval']:
+        if resp['retcode']:
             self.logger.error('Could not send command %s' % command)
         else:
             self.logger.debug('Successfully sent command %s' % command)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) [2016] [Philipp Zappa]
+Copyright (c) [2018] [Philipp Zappa, Darryl Masson]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Longwatch.py
+++ b/Longwatch.py
@@ -6,17 +6,17 @@ import time
 
 def main():
     db = DobermanDB.DobermanDB()
-    parser = argparse.ArgumentParser('%(prog)s: like tail -f but for Doberman messages')
+    parser = argparse.ArgumentParser(usage='%(prog)s: like tail -f but for Doberman messages')
     parser.add_argument('--delay', type=int, default=5,
                         help='How often to refresh (in seconds)')
-    parser.add_argument('--level', type=int, options=range(10,60,10), default=20,
+    parser.add_argument('--level', type=int, choices=range(10,60,10), default=20,
                         help='Minimum level of message to display')
     args = parser.parse_args()
     msg_format = '{when} | {level} | {name} | {funcname} | {lineno} | {msg}'
     try:
         while True:
             then = datetime.datetime.now() - timedelta(seconds = args.delay)
-            cursor = db.readFromDatabase('logging','logs', {'when' : {'$gt' : then}, 'level' : {'$geq' : args.level}})
+            cursor = db.readFromDatabase('logging','logs', {'when' : {'$gt' : then}, 'level' : {'$gte' : args.level}})
             for row in cursor:
                 print(msg_format.format(**row))
             time.sleep(args.delay)

--- a/Longwatch.py
+++ b/Longwatch.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import DobermanDB
+import argparse
+import datetime
+import time
+
+def main():
+    db = DobermanDB.DobermanDB()
+    parser = argparse.ArgumentParser('%(prog)s: like tail -f but for Doberman messages')
+    parser.add_argument('--delay', type=int, default=5,
+                        help='How often to refresh (in seconds)')
+    parser.add_argument('--level', type=int, options=range(10,60,10), default=20,
+                        help='Minimum level of message to display')
+    args = parser.parse_args()
+    msg_format = '{when} | {level} | {name} | {funcname} | {lineno} | {msg}'
+    try:
+        while True:
+            then = datetime.datetime.now() - timedelta(seconds = args.delay)
+            cursor = db.readFromDatabase('logging','logs', {'when' : {'$gt' : then}, 'level' : {'$geq' : args.level}})
+            for row in cursor:
+                print(msg_format.format(**row))
+            time.sleep(args.delay)
+    except KeyboardInterrupt:
+        print('Quiting is for losers, but ok')
+    finally:
+        db.close()
+    return
+
+if __name__ == '__main__':
+    main()

--- a/MKS_MFC.py
+++ b/MKS_MFC.py
@@ -1,5 +1,6 @@
 from ControllerBase import SerialController
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class MKS_MFC(SerialController):
@@ -48,7 +49,7 @@ class MKS_MFC(SerialController):
         self.ack_pattern = re.compile(f'{self._ACK}(?P<value>[^;]+);')
         self.setpoint_map = {'auto' : 'NORMAL', 'purge' : 'PURGE', 'close' : 'FLOW_OFF'}
         self.command_patterns = [
-                (re.compile(r'setpoint (?P<value>-?[0-9]+(?:\.[0-9]+)?)'),
+                (re.compile(r'setpoint (?P<value>%s)' % number_regex),
                     lambda x : self.setCommand.format(cmd=self.commands['SetpointValue'],
                         **x.groupdict())),
                 (re.compile(r'valve (?P<value>auto|close|purge)'),

--- a/Plugin.py
+++ b/Plugin.py
@@ -342,8 +342,8 @@ class Plugin(threading.Thread):
                                 {'name': self.name}, {'$set' : {'runmode' : runmode}})
             elif command == 'stop':
                 self.running = False
-                # in standalone mode Doberman will restart the plugin when it stops
                 self.has_quit = True
+                # makes sure we don't get restarted
             elif command == 'start':
                 runmode = self.db.ControllerSettings(name=self.name)['runmode']
                 self.db.updateDatabase('settings','controllers', {'name' : self.name},

--- a/Plugin.py
+++ b/Plugin.py
@@ -104,7 +104,7 @@ class Plugin(threading.Thread):
         #self.logger.debug('Opening controller...')
         self.OpenController()
         self.running = False
-        self.has_quit = False  # only used in standalone mode
+        self.has_quit = False
 
     def close(self):
         """Closes the controller, and sets the threading event"""
@@ -361,7 +361,7 @@ class Plugin(threading.Thread):
                 self.logger.error(f"Command '{command}' not accepted")
         return
 
-def main():
+def main(args_in=None):
     parser = argparse.ArgumentParser(description='Doberman plugin standalone')
     parser.add_argument('--name', type=str, dest='plugin_name', required=True,
                         help='Name of the controller')
@@ -369,7 +369,10 @@ def main():
                         help='Which run mode to use', default='default')
     parser.add_argument('--force', action='store_true', default=False,
                         help='Force the plugin to load (if it didn\'t reset)')
-    args = parser.parse_args()
+    if args_in:
+        args = parser.parse_args(args_in)
+    else:
+        args = parser.parse_args()
     plugin_paths=['.']
     logger = logging.getLogger(args.plugin_name)
     logger.addHandler(DobermanLogging.DobermanLogger())

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -27,13 +27,13 @@ class Teledyne(SerialController):
         self.command_echo = f'\\*{self.device_address}\\*:' + '{cmd} *;'
         self.retcode = f'!{self.device_address}!(?P<retcode>[beow])!'
 
-        self.setpoint_map = {'auto' : 0, 'open' : 1, 'closed' : 2}
+        self.setpoint_map = {'auto' : 0, 'open' : 1, 'close' : 2}
 
         self.command_patterns = [
                 (re.compile(r'setpoint (?P<params>-?[0-9]+(?:\.[0-9]+)?)'),
                     lambda x : self.setcommand.format(cmd=self.commands['SetpointValue'],
                         **x.groupdict())),
-                (re.compile(r'setpoint (?P<params>auto|open|closed)'),
+                (re.compile(r'valve (?P<params>auto|open|close)'),
                     lambda x : self.setcommand.format(cmd=self.commands['SetpointMode'],
                         params=self.setpoint_map[x.group('params')])),
                 ]

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -57,6 +57,6 @@ class Teledyne(SerialController):
             return resp
         m = self.get_reading.search(resp['data'])
         if not m:
-            return {'retcode' : -3, 'data' : -1}
+            return {'retcode' : -4, 'data' : -1}
         return {'retcode' : 0, 'data' : float(m.group('value'))}
 

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -44,7 +44,7 @@ class Teledyne(SerialController):
         resp = self.SendRecv(command, dev)
         if resp['retcode'] or not resp['data']:
             return False
-        m = self.get_addr.search.search(resp['data'])
+        m = self.get_addr.search(resp['data'])
         if not m:
             return False
         if self.device_address != m.group('addr'):

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -1,5 +1,6 @@
 from ControllerBase import SerialController
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class Teledyne(SerialController):
@@ -22,7 +23,7 @@ class Teledyne(SerialController):
         self.setcommand = self.basecommand + ' {params}'
         self.getcommand = self.basecommand + '?'
 
-        self.get_reading = re.compile(r'READ:(?P<value>-?[0-9]+(?:\.[0-9]+)?)')
+        self.get_reading = re.compile(r'READ:(?P<value>%s)' % number_regex)
         self.get_addr = re.compile(r'ADDR: *(?P<addr>[a-z])')
         self.command_echo = f'\\*{self.device_address}\\*:' + '{cmd} *;'
         self.retcode = f'!{self.device_address}!(?P<retcode>[beow])!'
@@ -30,7 +31,7 @@ class Teledyne(SerialController):
         self.setpoint_map = {'auto' : 0, 'open' : 1, 'close' : 2}
 
         self.command_patterns = [
-                (re.compile(r'setpoint (?P<params>-?[0-9]+(?:\.[0-9]+)?)'),
+                (re.compile(r'setpoint (?P<params>%s)' % number_regex),
                     lambda x : self.setcommand.format(cmd=self.commands['SetpointValue'],
                         **x.groupdict())),
                 (re.compile(r'valve (?P<params>auto|open|close)'),

--- a/caen_n1470.py
+++ b/caen_n1470.py
@@ -1,6 +1,7 @@
 from ControllerBase import SerialController
 import logging
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class caen_n1470(SerialController):
@@ -25,12 +26,12 @@ class caen_n1470(SerialController):
         self.setcommand = f'BD:{self.board},CMD:SET,' + 'CH:{ch},PAR:{par},VAL:{val}'
         self.powercommand = f'BD:{self.board},CMD:SET,' + 'CH:{ch},PAR:{par}'
         self.error_pattern = re.compile(',[A-Z]{2,3}:ERR')
-        self.read_pattern = re.compile('VAL:(?P<val>-?[0-9]+(?:\\.[0-9]+)?)')
+        self.read_pattern = re.compile('VAL:(?P<val>%s)' % number_regex)
         self.command_patterns = [
                 (re.compile('channel (?P<ch>anode|cathode) (?P<par>on|off)'),
                     lambda x : self.powercommand.format(
                         ch=self.channel_map[x.group('ch')],par=x.group('par'))),
-                (re.compile('channel (?P<ch>anode|cathode) (?P<par>vset|rup|rdw) (?P<val>-?[0-9]+(?:\\.[0-9]+)?)'),
+                (re.compile('channel (?P<ch>anode|cathode) (?P<par>vset|rup|rdw) (?P<val>%s' % number_regex),
                     lambda x : self.setcommand.format(ch=self.channel_map[x.group('ch')],
                         par=x.group('par').upper(), val=x.group('val'))),
                 ]

--- a/cryocon_22c.py
+++ b/cryocon_22c.py
@@ -1,5 +1,6 @@
 from ControllerBase import LANController
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class cryocon_22c(LANController):
@@ -21,16 +22,21 @@ class cryocon_22c(LANController):
                 'setSP' : 'loop {ch}:setpt {value}',
                 }
         super().__init__(opts)
-        self.read_pattern = re.compile(r'(?P<value>[0-9]+(?:\.[0-9]+)?)')
+        self.read_pattern = re.compile(r'(?P<value>%s)' % number_regex)
         self.command_patterns = [
-                (re.compile(r'setpoint (?P<ch>1|2) (?P<value>[0-9]+(?:\.[0-9]+)?)'),
+                (re.compile(r'setpoint (?P<ch>1|2) (?P<value>%s)' % number_regex),
                     lambda x : self.commands['setSP'].format(**x.groupdict())),
                 (re.compile('(shitshitfirezemissiles)|(loop stop)'),
-                    lambda x : 'stop'),
+                    self.FireMissiles),
                 ]
 
     def isThisMe(self, dev):
         return True  # don't have the same problems with LAN controllers
+
+    def FireMissiles(self, m):  # worth it for an entire function? Totally
+        if 'missiles' in m.group(0):
+            self.logger.warning('But I am leh tired...')
+        return 'stop'
 
     def Readout(self):
         resp = []

--- a/cryocon_22c.py
+++ b/cryocon_22c.py
@@ -48,9 +48,9 @@ class cryocon_22c(LANController):
                         stats.append(0)
                     else:
                         resp.append(-1)
-                        stats.append(-2)
+                        stats.append(-4)
                 except Exception as e:
                     self.logger.error('Could not read device! Error: %s' % e)
-                    return {'retcode' : -2, 'data' : None}
+                    return {'retcode' : -4, 'data' : None}
         return {'retcode' : stats, 'data' : resp}
 

--- a/heartbeat.py
+++ b/heartbeat.py
@@ -1,6 +1,7 @@
 from ControllerBase import Controller
 from subprocess import Popen, PIPE, TimeoutExpired
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class heartbeat(Controller):
@@ -10,9 +11,8 @@ class heartbeat(Controller):
     def __init__(self, opts):
         super().__init__(opts)
         self.command = f'ping -c {self.ping_count} {self.address}'
-        number = r'[0-9]+(?:\.[0-9]+)?'
         self.value_count = 4  # number of values returned
-        pattern = '/'.join([f'({number})']*self.value_count)
+        pattern = '/'.join([f'({number_regex})']*self.value_count)
         self.time_taken = re.compile(pattern)
         self.popen_args = {'shell' : True, 'stdout' : PIPE, 'stderr' : PIPE}
 

--- a/isegNHQ.py
+++ b/isegNHQ.py
@@ -47,10 +47,10 @@ class isegNHQ(SerialController):
 
     def isThisMe(self, dev):
         resp = self.SendRecv(self.commands['open'], dev)
-        if resp['retval']:
+        if resp['retcode']:
             return False
         resp = self.SendRecv(self.commands['identify'], dev)
-        if resp['retval'] or not resp['data']:
+        if resp['retcode'] or not resp['data']:
             return False
         if resp['data'].split(';')[0] == self.serialID:
             return True
@@ -65,7 +65,7 @@ class isegNHQ(SerialController):
         for com,func in zip(coms,funcs):
             cmd = self.getcommand.format(cmd=self.commands[com])
             resp = self.SendRecv(cmd)
-            status.append(resp['retval'])
+            status.append(resp['retcode'])
             if status[-1]:
                 vals.append[-1]
             else:

--- a/isegNHQ.py
+++ b/isegNHQ.py
@@ -1,6 +1,7 @@
 from ControllerBase import SerialController
 import time
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class isegNHQ(SerialController):
@@ -32,9 +33,9 @@ class isegNHQ(SerialController):
         super().__init__(opts)
 
         self.command_patterns = [
-                (re.compile(f'{cmd} (?P<value>-?[0-9]+(?:\\.[0-9]+)?)'),
-                    lambda x : self.setcommand.format(cmd=self.commands[f'{cmd}'],
-                        value=x.group('value'))) for cmd in ['Vset','Itrip','Vramp']
+                (re.compile('(?P<cmd>Vset|Itrip|Vramp) +(?P<value>%s)' % number_regex),
+                    lambda x : self.setcommand.format(cmd=self.commands[m.group('cmd'),
+                        value=m.group('value'))),
                 ]
 
 

--- a/iseries.py
+++ b/iseries.py
@@ -1,5 +1,6 @@
 from ControllerBase import SerialController
 import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
 
 
 class iseries(SerialController):
@@ -31,7 +32,7 @@ class iseries(SerialController):
                 'getAlarm2Low' : 'R15',
                 }
         super().__init__(opts)
-        self.read_pattern = re.compile(r'%s(?P<value>-?[0-9]+(?:\.[0-9]+)?)' % self.commands['getDisplayedValue'])
+        self.read_pattern = re.compile(r'%s(?P<value>%s)' % (self.commands['getDisplayedValue'], number_regex))
 
     def isThisMe(self, dev):
         info = self.SendRecv(self.commands['getAddress'], dev)

--- a/pfeiffer_tpg.py
+++ b/pfeiffer_tpg.py
@@ -1,0 +1,29 @@
+from ControllerBase import SerialController
+import re  # EVERYBODY STAND BACK xkcd.com/208
+from utils import number_regex
+
+
+class pfeiffer_tpg(SerialController):
+    def __init__(self, opts):
+        self._msg_begin = ''
+        self._msg_end = '\r\n\x05\r\n'
+        super().__init__(opts)
+        self.commands = {
+                'identify' : 'AYT',
+                'read' : 'PRX',
+                }
+        self.read_command = re.compile(r'[0-9],(?P<value>%s)' % number_regex)
+
+    def Readout(self):
+        resp = self.SendRecv(self.commands['read'])
+        if resp['retcode']:
+            return resp
+        m = self.read_command.search(resp['data'])
+        if not m:
+            self.logger.debug('Error?')
+            return {'retcode' : -3, 'data' : -1}
+        return {'retcode' : 0, 'data' : float(m.group('value'))}
+
+    def isThisMe(self, dev):
+        pass
+

--- a/settings/Database_connectiondetails.txt
+++ b/settings/Database_connectiondetails.txt
@@ -1,1 +1,0 @@
-{'host' : 'localhost', 'port' : 13178, 'username' : 'doberman', 'password' : 'h5jlm42'}

--- a/smartec_uti.py
+++ b/smartec_uti.py
@@ -94,7 +94,7 @@ class smartec_uti(SerialController):
             val['retcode'] = stat
         except Exception as e:
             self.logger.error('LM error: %s' % e)
-            val['retcode'] = -3
+            val['retcode'] = -4
             val['data'] = None
         return val
 

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ from Plugin import FindPlugin
 import serial
 
 
-number_regex = r'-?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
+number_regex = r'[\-+]?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
 
 def getUserInput(text, input_type=None, be_in=None, be_not_in=None, be_array=False, limits=None, string_length=None, exceptions=None):
     """

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 from ast import literal_eval
 
+number_regex = r'-?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
 
 def getUserInput(text, input_type=None, be_in=None, be_not_in=None, be_array=False, limits=None, string_length=None, exceptions=None):
     """


### PR DESCRIPTION
Separates the running of plugins from Doberman. Doberman now starts plugins in standalone mode and lets them do their thing. Issues the 'all stop' command when it returns.

Added an 'all' option to commands, which distributes the given command to all currently running controllers. Adds a 'online' field to each controller doc which serves as its lockfile (also added a `--force` command-line option that ignores this - use at your own risk). Replaces the lockfile functionality with a field in the `settings.defaults` collection.

Changed `stilltesting` in the logging module to `False`, so log messages are now stored in the database rather than put to screen (except for `debug` level messages, which are not stored). Also added a `Longwatch` script that pulls log and prints log messages, so logs from controllers running in the background can be seen.