### PR TITLE
Fix for crashing iseries

### DIFF
--- a/ControllerBase.py
+++ b/ControllerBase.py
@@ -134,7 +134,7 @@ class SerialController(Controller):
         try:
             message = self._msg_start + str(message) + self._msg_end
             device.write(message.encode())
-            time.sleep(0.5)
+            time.sleep(1.0)
             if device.in_waiting:
                 ret['data'] = device.read(device.in_waiting).decode().rstrip()
         except serial.SerialException as e:

--- a/Doberman.py
+++ b/Doberman.py
@@ -13,7 +13,7 @@ from threading import Thread
 import utils
 dtnow = datetime.datetime.now
 
-__version__ = '2.0.0'
+__version__ = '2.1.1'
 
 class Doberman(object):
     '''

--- a/iseries.py
+++ b/iseries.py
@@ -1,6 +1,7 @@
 from ControllerBase import SerialController
 import re  # EVERYBODY STAND BACK xkcd.com/208
 from utils import number_regex
+import time
 
 
 class iseries(SerialController):
@@ -50,11 +51,16 @@ class iseries(SerialController):
     def Readout(self):
         val = self.SendRecv(self.commands['getDisplayedValue'])
         if not val['data'] or val['retcode']:
-            self.logger.error('No data??')
-            return val
+            self.logger.debug('No data?')
+            time.sleep(1)
+            val = self.SendRecv(self.commands['getDisplayedValue'])
+            if not val['data'] or val['retcode']:
+                self.logger.error('No data!')
+                return val
         m = self.read_pattern.search(val['data'])
         if not m:
             self.logger.error('Device didn\'t echo correct command')
+            val['retcode'] = -4
             val['data'] = -1
             return val
         val['data'] = float(m.group('value'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyserial
+pyserial=3.4
 pyusb==1.0 #for Plugin oxford_itc503
-pymongo
+pymongo=3.7


### PR DESCRIPTION
Increases the waiting time between asking a serial device for a measurement and reading the value out. Also gives the iseries a second chance to return data if it doesn't the first time (fixing #27).