### PR TITLE
Daemonize

### DIFF
--- a/ControllerBase.py
+++ b/ControllerBase.py
@@ -1,6 +1,4 @@
-from subprocess import Popen, PIPE, TimeoutExpired
 import serial
-import os.path
 import socket
 import time
 import logging
@@ -65,7 +63,7 @@ class Controller(object):
         positions, etc)
         """
         if not hasattr(self, 'command_patterns'):
-            raise NotImplementedError()
+            self.logger.error("I don't accept specific commands")
         for pattern, func in self.command_patterns:
             m = pattern.search(command)
             if not m:

--- a/Doberman.py
+++ b/Doberman.py
@@ -69,7 +69,7 @@ class Doberman(object):
             self.logger.debug('Not updating tty settings')
         return 0
 
-    def StartController(self, name, runmode='default'):
+    def StartController(self, name, runmode='testing'):
         """
         Starts the specified controller and releases it into the wild
         """

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -176,7 +176,7 @@ class DobermanDB(object):
         Stores commands for the system. Command == 'help' describes accepted commands
         """
         names = self.Distinct('settings','controllers','name')
-        names_ = '|'.join(names)
+        names_ = '|'.join(names + ['all'])
         runmodes_ = '|'.join(self.Distinct('settings','runmodes','mode'))
         whoami = os.environ['USER']
         if command_str.startswith('help'):

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -532,7 +532,7 @@ def main():
     db = DobermanDB()
     parser.add_argument('--update', action='store_true', default=False,
                         help='Update settings/contacts/etc')
-    parser.add_argument('command', nargs='+',
+    parser.add_argument('command', nargs='*',
                         help='Issue a command to the system. Format: '
                             '<name> <command>. Try \'help\'')
     parser.add_argument('--add-runmode', action='store_true', default=False,

--- a/DobermanLogging.py
+++ b/DobermanLogging.py
@@ -6,7 +6,7 @@ import os
 
 class DobermanLogger(logging.Handler):
     """
-    Custom logging interface for Doberman. Gives us the option to log to
+    Custom logging interface for Doberman. Logs to
     the database (with disk as backup).
     """
     def __init__(self, db):
@@ -25,13 +25,19 @@ class DobermanLogger(logging.Handler):
         self.setFormatter(f)
         self.stream.setFormatter(f)
 
+    def close(self):
+        self.backup_logger.close()
+        self.stream.close()
+        self.db = None
+        return
+
     def __del__(self):
-        #self.db.close()  # doesn't own db instance
+        self.close()
         return
 
     def emit(self, record):
-        self.stream.emit(record)
-        if record.levelno <= logging.INFO:
+        #self.stream.emit(record)
+        if record.levelno < logging.INFO:
             return
         rec = dict(when     = datetime.datetime.fromtimestamp(record.created),
                 msg         = record.msg,

--- a/Longwatch.py
+++ b/Longwatch.py
@@ -15,7 +15,7 @@ def main():
     msg_format = '{when} | {level} | {name} | {funcname} | {lineno} | {msg}'
     try:
         while True:
-            then = datetime.datetime.now() - timedelta(seconds = args.delay)
+            then = datetime.datetime.now() - datetime.timedelta(seconds = args.delay)
             cursor = db.readFromDatabase('logging','logs', {'when' : {'$gt' : then}, 'level' : {'$gte' : args.level}})
             for row in cursor:
                 print(msg_format.format(**row))

--- a/Plugin.py
+++ b/Plugin.py
@@ -21,7 +21,7 @@ class Plugin(threading.Thread):
     to the database.
     """
 
-    def __init__(self, name, plugin_paths, force=False):
+    def __init__(self, db, name, plugin_paths, force=False):
         """
         Constructor
 
@@ -44,7 +44,7 @@ class Plugin(threading.Thread):
         self.logger = logging.getLogger(name)
         self.name = name
         self.logger.debug('Starting plugin...')
-        self.db = DobermanDB.DobermanDB()
+        self.db = db
         config_doc = self.db.readFromDatabase('settings','controllers',
                 {'name' : self.name}, onlyone=True)
         self.controller_ctor = utils.FindPlugin(self.name, plugin_paths)
@@ -58,6 +58,7 @@ class Plugin(threading.Thread):
         self.number_of_data = int(config_doc['number_of_data'])
         self.description = config_doc['description']
         self.recurrence_counter = [0] * self.number_of_data
+        self.status_counter = [0] * self.number_of_data
         self.last_message_time = dtnow()
         self.late_counter = 0
         self.last_measurement_time = dtnow()
@@ -67,15 +68,13 @@ class Plugin(threading.Thread):
         self.has_quit = False
 
     def close(self):
-        """Closes the controller, and sets the threading event"""
+        """Closes the controller"""
         self.running = False
-        if self.controller:
-            self.logger.info('Stopping...')
-            self.controller.close()
-        else:
-            self.logger.info('Already stopped!')
+        if not self.controller:
+            return
+        self.logger.info('Stopping...')
+        self.controller.close()
         self.controller = None
-        self.db.close()
         return
 
     def OpenController(self):
@@ -85,7 +84,7 @@ class Plugin(threading.Thread):
         try:
             self.controller = self.controller_ctor(self.ctor_opts)
         except Exception as e:
-            self.logger.error('Could not open controller')
+            self.logger.error('Could not open controller. Error: %s' % e)
             self.controller = None
             raise
         else:
@@ -210,18 +209,22 @@ class Plugin(threading.Thread):
             try:
                 if alarm_status[i] != 'ON':
                     continue
-                if status[i] < 0 and not too_soon:
-                    msg = f'Something wrong? Status[{i}] is {status[i]}'
-                    self.logger.warning(msg)
-                    self.db.logAlarm({'name' : self.name, 'index' : i,
-                        'when' : when, 'status' : status[i], 'data' : values[i],
-                        'reason' : 'NC', 'howbad' : 1, 'msg' : msg})
+                if status[i] < 0:
+                    self.status_counter[i] += 1
+                    if self.status_counter[i] >= 3 and not too_soon:
+                        msg = f'Something wrong? Status[{i}] is {status[i]}'
+                        self.logger.warning(msg)
+                        self.db.logAlarm({'name' : self.name, 'index' : i,
+                            'when' : when, 'status' : status[i], 'data' : values[i],
+                            'reason' : 'NC', 'howbad' : 1, 'msg' : msg})
+                        self.last_message_time = dtnow()
+                        self.status_counter[i] = 0
                 elif clip(values[i], alarm_low[i], alarm_high[i]) in \
                     [alarm_low[i], alarm_high[i]]:
                     self.recurrence_counter[i] += 1
                     status[i] = 2
                     if self.recurrence_counter[i] >= recurrence[i] and not too_soon:
-                        msg = (f'Reading {i} ({self.description[i]}, '
+                        msg = (f'Reading {i} ({self.description[i]}, value '
                                f'{values[i]:.2f}) is outside the alarm range '
                                f'({alarm_low[i]:.2f}, {alarm_high[i]:.2f})')
                         self.logger.critical(msg)
@@ -235,7 +238,7 @@ class Plugin(threading.Thread):
                     self.recurrence_counter[i] += 1
                     status[i] = 1
                     if self.recurrence_counter[i] >= recurrence[i] and not too_soon:
-                        msg = (f'Reading {i} ({self.description[i]}, '
+                        msg = (f'Reading {i} ({self.description[i]}, value '
                                 f'{values[i]:.2f}) is outside the warning range '
                                 f'({warning_low[i]:.2f}, {warning_high[i]:.2f})')
                         self.logger.warning(msg)
@@ -246,6 +249,7 @@ class Plugin(threading.Thread):
                         self.last_message_time = dtnow()
                 else:
                     self.recurrence_counter[i] = 0
+                    self.status_counter[i] = 0
             except Exception as e:
                 self.logger.critical(f'Could not check data[{i}]: {e}')
         if not self._connected:
@@ -281,28 +285,24 @@ class Plugin(threading.Thread):
         ------
         None
         """
-        doc_filter = {'name' : self.name, 'acknowledged' : {'$exists' : 0},
+        doc_filter = lambda : {'name' : self.name, 'acknowledged' : {'$exists' : 0},
                 'logged' : {'$lte' : dtnow()}}
-        collection = self.db._check('logging','commands')
-        while collection.count_documents(doc_filter):
-            updates = {'$set' : {'acknowledged' : dtnow()}}
-            command = collection.find_one_and_update(doc_filter, updates)['command']
+        updates = lambda : {'$set' : {'acknowledged' : dtnow()}}
+        doc = self.db.FindCommand(doc_filter(), updates())
+        while doc is not None:
+            command = doc['command']
             self.logger.info(f"Found command '{command}'")
             if 'runmode' in command:
-                try:
-                    _, runmode = command.split()
-                except ValueError:
-                    self.logger.error(f"Could not understand command '{command}'")
-                else:
-                    self.db.updateDatabase('settings','controllers',
+                _, runmode = command.split()
+                self.db.updateDatabase('settings','controllers',
                                 {'name': self.name}, {'$set' : {'runmode' : runmode}})
-                    loglevel = db.getDefaultSettings(runmode=runmode,name='loglevel')
-                    self.logger.setLevel(int(loglevel))
+                loglevel = self.db.getDefaultSettings(runmode=runmode,name='loglevel')
+                self.logger.setLevel(int(loglevel))
             elif command == 'stop':
                 self.running = False
                 self.has_quit = True
                 # makes sure we don't get restarted
-            elif command == 'start':
+            elif command == 'wake':
                 runmode = self.db.ControllerSettings(name=self.name)['runmode']
                 self.db.updateDatabase('settings','controllers', {'name' : self.name},
                         {'$set' : {'status.%s' % runmode : 'ON'}})
@@ -310,26 +310,22 @@ class Plugin(threading.Thread):
                 runmode = self.db.ControllerSettings(name=self.name)['runmode']
                 self.db.updateDatabase('settings','controllers', {'name' : self.name},
                         {'$set' : {'status.%s' % runmode : 'OFF'}})
-            elif command == 'restart':
-                self.running = False
-                # don't set has_quit here, so main() restarts us
             elif self._connected:
                 self.controller.ExecuteCommand(command)
             else:
                 self.logger.error(f"Command '{command}' not accepted")
+            doc = self.db.FindCommand(doc_filter(), updates())
         return
 
 def main(args_in=None):
     db = DobermanDB.DobermanDB()
-    names = db._check('settings','controllers').distinct('name')
-    runmodes = db._check('settings','runmodes').distinct('mode')
+    names = db.Distinct('settings','controllers','name')
+    runmodes = db.Distinct('settings','runmodes','mode')
     parser = argparse.ArgumentParser(description='Doberman plugin standalone')
     parser.add_argument('--name', type=str, dest='plugin_name', required=True,
                         help='Name of the controller',choices=names)
     parser.add_argument('--runmode', type=str, dest='runmode', choices=runmodes,
                         help='Which run mode to use', default='default')
-    parser.add_argument('--force', action='store_true', default=False,
-                        help='Force the plugin to load (if it didn\'t reset)')
     if args_in:
         args = parser.parse_args(args_in)
     else:
@@ -340,20 +336,23 @@ def main(args_in=None):
     loglevel = db.getDefaultSettings(runmode=args.runmode,name='loglevel')
     logger.setLevel(int(loglevel))
     doc = db.readFromDatabase('settings','controllers',{'name' : args.plugin_name},onlyone=True)
-    if doc['online'] and not args.force:
+    if doc['online']:
         logger.fatal('%s already running!' % args.plugin_name)
         db.close()
         return
     db.updateDatabase('settings','controllers',{'name' : args.plugin_name},
             {'$set' : {'runmode' : args.runmode, 'online' : True}})
 
-    plugin = Plugin(args.plugin_name, plugin_paths, args.force)
+    plugin = Plugin(db, args.plugin_name, plugin_paths)
     plugin.start()
+    sh = utils.SignalHandler()
     running = True
     try:
-        while running:
+        while running and not sh.interrupted:
+            loop_start = time.time()
             logger.debug('I\'m still here')
-            time.sleep(30)
+            while time.time() - loop_start < 30 and not sh.interrupted:
+                time.sleep(1)
             if plugin.has_quit:
                 logger.info('Plugin stopped')
                 break
@@ -362,7 +361,7 @@ def main(args_in=None):
                 try:
                     plugin.running = False
                     plugin.join()
-                    plugin = Plugin(args.plugin_name, plugin_paths, args.force)
+                    plugin = Plugin(args.plugin_name, plugin_paths)
                     plugin.start()
                 except Exception as e:
                     logger.critical('Could not restart %s' % plugin.name)
@@ -376,6 +375,7 @@ def main(args_in=None):
         plugin.join()
         db.updateDatabase('settings','controllers',{'name' : args.plugin_name},
                 {'$set' : {'online' : False}})
+        logging.shutdown()
         db.close()
 
     return

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -1,6 +1,7 @@
 from ControllerBase import SerialController
 import re  # EVERYBODY STAND BACK xkcd.com/208
 from utils import number_regex
+import time
 
 
 class Teledyne(SerialController):
@@ -62,6 +63,14 @@ class Teledyne(SerialController):
             return resp
         m = self.get_reading.search(resp['data'])
         if not m:
-            return {'retcode' : -4, 'data' : -1}
+            self.logger.debug('Lemme try again')
+            time.sleep(1)
+            resp = self.SendRecv(command)
+            if resp['retcode'] or not resp['data']:
+                self.logger.error('No data')
+                return resp
+            m = self.get_reading.search(resp['data'])
+            if not m:
+                return {'retcode' : -4, 'data' : -1}
         return {'retcode' : 0, 'data' : float(m.group('value'))}
 

--- a/alarmDistribution.py
+++ b/alarmDistribution.py
@@ -4,6 +4,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import DobermanDB
+import sys
 
 
 class alarmDistribution(object):
@@ -212,3 +213,14 @@ class alarmDistribution(object):
         print 'Return data: %s' % str(send_ret)
         '''
 
+def main():
+    db = DobermanDB.DobermanDB()
+    aldist = alarmDistribution(db)
+    msg = 'Something wrong with Doberman? The following things aren\'t heartbeating correctly:\n'
+    msg += ' '.join(sys.argv[1:])
+    to_addr = [c['email'] for c in db.getContacts('email')]
+    aldist.sendEmail(toaddr=to_addr, subject='Doberman heartbeat', message=msg)
+    db.close()
+
+if __name__ == '__main__':
+    main()

--- a/caen_n1470.py
+++ b/caen_n1470.py
@@ -14,26 +14,29 @@ class caen_n1470(SerialController):
     correct:
     '#BD:<board number>,CMD:OK[,VAL:<value>[,<value>...]]'
     """
+    accepted_commands = [
+        '<anode|cathode> <on|off>',
+        '<anode|cathode> vset <value>',
+    ]
 
     def __init__(self, opts):
         super().__init__(opts)
         self._msg_start = '$'
         self._msg_end = '\r\n'
-        self.commands = {'read' : f'BD:{self.board},' + 'CMD:MON,CH{ch},PAR:{par}',
-                        'write' : f'BD:{self.board},' + 'CMD:SET,CH{ch},PAR:{par},VAL:{val}',
+        self.commands = {'read' : f'BD:{self.board},' + 'CMD:MON,CH:{ch},PAR:{par}',
                         'name' : f'BD:{self.board},CMD:MON,PAR:BDNAME',
                         'snum' : f'BD:{self.board},CMD:MON,PAR:BDSNUM'}
         self.setcommand = f'BD:{self.board},CMD:SET,' + 'CH:{ch},PAR:{par},VAL:{val}'
         self.powercommand = f'BD:{self.board},CMD:SET,' + 'CH:{ch},PAR:{par}'
         self.error_pattern = re.compile(',[A-Z]{2,3}:ERR')
-        self.read_pattern = re.compile('VAL:(?P<val>%s)' % number_regex)
+        self.read_pattern = re.compile('VAL:%s' % ';'.join(['(?P<val%i>%s)' % (i, number_regex) for i in range(4)]))
         self.command_patterns = [
-                (re.compile('channel (?P<ch>anode|cathode) (?P<par>on|off)'),
+                (re.compile('(?P<ch>anode|cathode) (?P<par>on|off)'),
                     lambda x : self.powercommand.format(
-                        ch=self.channel_map[x.group('ch')],par=x.group('par'))),
-                (re.compile('channel (?P<ch>anode|cathode) (?P<par>vset|rup|rdw) (?P<val>%s' % number_regex),
+                        ch=self.channel_map[x.group('ch')],par=x.group('par').upper())),
+                (re.compile('(?P<ch>anode|cathode) vset (?P<val>%s)' % number_regex),
                     lambda x : self.setcommand.format(ch=self.channel_map[x.group('ch')],
-                        par=x.group('par').upper(), val=x.group('val'))),
+                        par='VSET', val=x.group('val'))),
                 ]
 
     def isThisMe(self, dev):
@@ -57,16 +60,26 @@ class caen_n1470(SerialController):
         """
         readings = []
         status = []
-        for com in ['VMON','IMON','STAT']:
-            for ch in self.channels:
-                res = SendRecv(self.commands['read'].format(ch=ch,par=com))
-                if res['retcode'] or 'ERR' in res['data']:
-                    readings.append[-1]
-                    status.append[-1]
-                    self.logger.error('Error reading ch %i: %s' % (ch,res['data'].split(',')[1]))
-                else:
-                    status.append[0]
-                    val = res['data'].split(',')[2]
-                    readings.append(float(val))
+        ch = 4  # reads all channels in one command
+        for com in ['VMON','VSET','IMON','STAT']:
+            res = self.SendRecv(self.commands['read'].format(ch=ch,par=com))
+            if not res['data'] or res['retcode']:
+                readings += [-1] * len(self.channel_map)
+                status += [res['retcode']] * len(self.channel_map)
+                self.logger.error("No data for %s" % com)
+                continue
+            m = self.error_pattern.search(res['data'])
+            if m:
+                readings += [-1] * len(self.channel_map)
+                status += [-3] * len(self.channel_map)
+                self.logger.error('Error reading %s: %s' % (com,m.group(0)))
+                continue
+            m = self.read_pattern.search(res['data'])
+            if m:
+                status += [0] * len(self.channel_map)
+                readings += map(float, [m.group('val%i' % i) for _,i in self.channel_map.items()])
+            else:
+                status += [-4] * len(self.channel_map)
+                readings += [-1] * len(self.channel_map)
         return {'retcode' : status, 'data' : readings}
 

--- a/doberman.service
+++ b/doberman.service
@@ -9,7 +9,7 @@ Type=simple
 Restart=always
 RestartSec=3
 User=doberman
-ExecStart=/scratch/anaconda3/envs/Doberman/bin/python3 /scratch/doberman/Doberman.py
+ExecStart=/scratch/doberman/Doberman.py
 
 [Install]
 WantedBy=multi-user.target

--- a/doberman.service
+++ b/doberman.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Doberman slow control
+After=mongod.service
+StartLimitInvervalSec=30
+StartLimitBurst=10
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=3
+User=doberman
+ExecStart=/scratch/anaconda3/envs/Doberman/bin/python3 /scratch/doberman/Doberman.py
+
+[Install]
+WantedBy=multi-user.target

--- a/pfeiffer_tpg.py
+++ b/pfeiffer_tpg.py
@@ -17,6 +17,7 @@ class pfeiffer_tpg(LANController):
     def _getControl(self):
         super()._getControl()
         self.SendRecv(self.commands['identify'])
+        return True
         # stops the continuous flow of data
 
     def Readout(self):

--- a/utils.py
+++ b/utils.py
@@ -217,13 +217,21 @@ def FindPlugin(name, path):
     ------
     FileNotFoundError
         If the specified file can't be found
+    AttributeError
+        If the constructor can't be found
     """
-    if name != 'RAD7':
-        name = name.strip('0123456789')
     spec = importlib.machinery.PathFinder.find_spec(name, path)
     if spec is None:
+        spec = importlib.machinery.PathFinder.find_spec(name.strip('0123456789'), path)
+    if spec is None:
         raise FileNotFoundError('Could not find a controller named %s' % name)
-    controller_ctor = getattr(spec.loader.load_module(), name)
+    try:
+        controller_ctor = getattr(spec.loader.load_module(), name)
+    except AttributeError:
+        try:
+            controller_ctor = getattr(spec.loader.load_module(), name.strip('0123456789'))
+        except AttributeError:
+            raise AttributeError('Cound not find constructor for %s!' % name)
     return controller_ctor
 
 class SignalHandler(object):


### PR DESCRIPTION
Implements #30, elevating Doberman to a service controllable via systemctl. Controllers can be started and stopped by issuing commands via the database interface. Doberman now no longer runs in its own environment (what with the system control), so the necessary libraries (pyserial and pymongo) were installed in the default environment. The mongo connection uri is stored plaintext in a file in the doberman directory (as the previously-used environmental parameter is no longer available). The regular expressions that parsed commands were cleaned up, and the service file is now provided. It can be symlinked to /var/systemd/system or copied.