### PR TITLE
Added runmodes to help command

### DIFF
--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -216,6 +216,10 @@ class DobermanDB(object):
         print()
         print('Plugin name == "all" issues the command to all running plugins')
         print()
+        print('Available runmodes:')
+        runmodes = self.Distinct('settings','runmodes','mode')
+        print(' | '.join(runmodes))
+        print()
         return
 
     def StoreCommand(self, command_str):


### PR DESCRIPTION
Fixes #44. Listing runmodes is possible via the `--help` command line option in Plugin.py, but there's no reason why it shouldn't be under the main command help routine.