### PR TITLE
Everything now heartbeats

### DIFF
--- a/Doberman.py
+++ b/Doberman.py
@@ -71,8 +71,7 @@ class Doberman(object):
         Starts the specified controller and releases it into the wild
         """
         self.logger.info('Starting %s' % name)
-        if name not in self.managed_plugins:
-            self.managed_plugins.append(name)
+        seld.db.ManagePlugins(name, 'add')
         cmd = '/scratch/anaconda3/envs/Doberman/bin/python3 Plugin.py --name %s --runmode %s' % (name, runmode)
         _ = Popen(cmd, shell=True, stdout=DEVNULL, stderr=DEVNULL, close_fds=False, cwd='/scratch/doberman')
 
@@ -81,7 +80,7 @@ class Doberman(object):
         Watches all the bees
         '''
         self.sleep = False
-        loop_time = 30
+        loop_time = utils.heartbeat_timer
         self.logger.info('Watch ALL the bees!')
         sh = utils.SignalHandler(self.logger)
         self.start_time = dtnow()
@@ -103,7 +102,8 @@ class Doberman(object):
 
     def Heartbeat(self):
         self.db.Heartbeat('doberman')
-        for name in self.managed_plugins:
+        managed_plugins = self.db.getDefaultSettings(name='managed_plugins')
+        for name in managed_plugins:
             time_since = self.db.CheckHeartbeat(name)
             if time_since > 3*utils.heartbeat_timer:
                 self.logger.info('%s hasn\'t reported in recently (%i seconds). Let me try restarting it...' % (name, time_since))

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -186,6 +186,27 @@ class DobermanDB(object):
                 ret[p].append(doc[p])
         return ret
 
+    def Heartbeat(self, name):
+        """
+        Heartbeats the specified controller (or doberman)
+        """
+        if name == 'doberman':
+            cuts={}
+        else:
+            cuts={'name' : name}
+        self.updateDatabase('settings','defaults',cuts=cuts,
+                    updates={'$set' : {'heartbeat' : dtnow()}})
+        return
+
+    def CheckHeartbeat(self, name):
+        """
+        Checks the heartbeat of the specified controller.
+        Returns time_since
+        """
+        doc = self.ControllerConfig(name=name)
+        last_heartbeat = doc['heartbeat']
+        return (dtnow() - last_heartbeat).total_seconds()
+
     def PrintHelp(self, name):
         print('Accepted commands:')
         print('help <plugin_name>: help for specific plugin')

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -334,6 +334,25 @@ class DobermanDB(object):
             return doc[name]
         return doc
 
+    def ManagePlugins(self, name, action):
+        """
+        Adds or removes a plugin from the managed list. Doberman adds, plugins remove
+        """
+        managed_plugins = self.getDefaultSettings(name='managed_plugins')
+        if action='add':
+            if name in managed_plugins:
+                self.logger.info('%s already managed' % name)
+            else:
+                self.updateDatabase('settings','defaults',cuts={},
+                        updates={'$push' : {'managed_plugins' : name}})
+        elif action='remove':
+            if name not in managed_plugins:
+                self.logger.debug('%s isn\'t managed' % name)
+            else:
+                self.updateDatabase('settings','defaults',cuts={},
+                        updates={'$pull' : {'managed_plugins' : name}})
+        return
+
     def updateContacts(self):
         """
         Update active contacts

--- a/Plugin.py
+++ b/Plugin.py
@@ -72,6 +72,7 @@ def main(db):
         plugin.running = False
         plugin.join()
         logger.info('Shutting down')
+        db.ManagePlugins(args.plugin_name, 'remove')
 
     return
 

--- a/Plugin.py
+++ b/Plugin.py
@@ -45,8 +45,9 @@ def main(db):
     try:
         while running and not sh.interrupted:
             loop_start = time.time()
+            db.Heartbeat(plugin.name)
             logger.debug('I\'m still here')
-            while time.time() - loop_start < 30 and not sh.interrupted:
+            while time.time() - loop_start < utils.heartbeat_timer and not sh.interrupted:
                 time.sleep(1)
             if plugin.has_quit:
                 logger.info('Plugin stopped')

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ import datetime
 import signal
 dtnow = datetime.datetime.now
 
-
+heartbeat_timer = 30
 number_regex = r'[\-+]?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
 
 def getUserInput(text, input_type=None, be_in=None, be_not_in=None, be_array=False, limits=None, string_length=None, exceptions=None):


### PR DESCRIPTION
Fixes #48 by adding heartbeats into the controlling executable for every plugin. If a plugin doesn't report in when it should, Doberman tries to restart it. If this is unsuccessful, an alarm is issued.

To handle this, Doberman keeps track of which plugins it starts and checks the heartbeat of only these.