### PR TITLE
Fixes unicode decode error

### DIFF
--- a/BasePlugin.py
+++ b/BasePlugin.py
@@ -156,8 +156,10 @@ class Plugin(threading.Thread):
             if len(vals['retcode']) != self.number_of_data:
                 vals['retcode'] += [-3]*(self.number_of_data - len(vals['data']))
             data = [dtnow(), vals['data'], vals['retcode']]
-            if vals['data']:
-                self.logger.debug('Measured %s' % list(map('{:.2g}'.format, vals['data'])))
+            try:
+                self.logger.debug('Measured %s' % (list(map('{:.3g}'.format, vals['data']))))
+            except:
+                pass
             if -1 in data[2] or -2 in data[2]: # connection lost
                 self._connected = False
                 self.logger.error('Lost connection to device?')
@@ -237,7 +239,7 @@ class Plugin(threading.Thread):
                 else:
                     self.recurrence_counter[i] = 0
             except Exception as e:
-                self.logger.critical(f"Could not check reading {i} ({reading['description']}): {e} ({str(type(e))}")
+                self.logger.critical(f"Could not check reading {i} ({reading['description']}): {e} ({str(type(e))})")
         if not self._connected:
             return
         time_diff = (when - self.last_measurement_time).total_seconds()

--- a/ControllerBase.py
+++ b/ControllerBase.py
@@ -141,7 +141,8 @@ class SerialController(Controller):
             device.write(message.encode())
             time.sleep(1.0)
             if device.in_waiting:
-                ret['data'] = device.read(device.in_waiting).decode().rstrip()
+                s = device.read(device.in_waiting)
+                ret['data'] = s.decode().rstrip()
         except serial.SerialException as e:
             self.logger.error('Could not send message %s. Error %s' % (message, e))
             ret['retcode'] = -2
@@ -150,6 +151,9 @@ class SerialController(Controller):
             self.logger.error('Could not send message %s. Error %s' % (message, e))
             ret['retcode'] = -2
             return ret
+        except UnicodeDecodeError as e:
+            self.logger.error('Unicode problems: %s. I\'m going to pass this along undecoded and hope your sensor knows how to handle it. Data: %s' % (e, s))
+            ret['data'] = s
         time.sleep(0.2)
         return ret
 


### PR DESCRIPTION
The Teledyne sometimes returns bytes that `bytes.decode()` can't handle. This causes the code to throw unexpected exceptions (it starts with a `UnicodeDecodeException` in `ControllerBase.py`, but is somehow converted into a `TypeError` about string formatting when it reaches the end) which crashes the plugin. This PR improves the way the code handles un-decodable strings by catching the exception and sending the un-decoded string upstream and assuming the plugin code will deal with it.