### PR TITLE
Restarts after crashes

### DIFF
--- a/Doberman.py
+++ b/Doberman.py
@@ -201,9 +201,11 @@ def main(db):
     parser.add_argument('--refresh', action='store_true', default=False,
                         help='Refresh the ttyUSB mapping')
     opts = parser.parse_args()
-    if db.getDefaultSettings(name='status') == 'online':
-        logger.error('Is there an instance of Doberman already running?')
-        return 2
+    doc = db.getDefaultSettings()
+    if doc['status'] == 'online':
+        if (dtnow() - doc['heartbeat']).total_seconds() < 3*utils.heartbeat_timer:
+            logger.error('Is there an instance of Doberman already running?')
+            return 2
     if opts.version:
         logger.info('Doberman version %s' % __version__)
         return 0

--- a/Plugin.py
+++ b/Plugin.py
@@ -8,6 +8,7 @@ import utils
 from BasePlugin import Plugin
 from PID import FeedbackController
 from BlindPlugin import BlindPlugin
+import datetime
 
 
 def main(db):
@@ -26,9 +27,10 @@ def main(db):
     loglevel = db.getDefaultSettings(runmode=args.runmode,name='loglevel')
     logger.setLevel(int(loglevel))
     doc = db.ControllerSettings(args.plugin_name)
-    if doc['online']:
-        logger.fatal('%s already running!' % args.plugin_name)
-        return
+    if doc['status'] == 'online':
+        if (datetime.datetime.now() - doc['heartbeat']).total_seconds < 3*utils.heartbeat_timer:
+            logger.fatal('%s already running!' % args.plugin_name)
+            return
     db.updateDatabase('settings','controllers',{'name' : args.plugin_name},
             {'$set' : {'runmode' : args.runmode, 'online' : True}})
     logger.info('Starting %s' % args.plugin_name)


### PR DESCRIPTION
If the database thinks that the Doberman executable is running when it starts, it then checks to see how recently the last heartbeat was. If this is too far in the past, it ignores the "online" field and starts anyway. This should allow the system to recover if it is not stopped gracefully.