### PR TITLE
Plugin management depends on kill signal

### DIFF
--- a/Plugin.py
+++ b/Plugin.py
@@ -74,7 +74,9 @@ def main(db):
         plugin.running = False
         plugin.join()
         logger.info('Shutting down')
-        db.ManagePlugins(args.plugin_name, 'remove')
+        if hasattr(sh, 'signal_number') and sh.signal_number == 2:
+            # only unmanage for SIGINT not SIGKILL
+            db.ManagePlugins(args.plugin_name, 'remove')
 
     return
 

--- a/utils.py
+++ b/utils.py
@@ -245,4 +245,5 @@ class SignalHandler(object):
 
     def interrupt(self, *args):
         self.logger.info('Received signal %i' % args[0])
+        self.signal_number = int(args[0])
         self.interrupted = True


### PR DESCRIPTION
Fixes #59 by having plugins un-manage themselves only when killed with SIGINT (2), rather than SIGKILL (15). This way, when Doberman restarts, there will still be plugins in the managed list that it will restart sooner or later