### PR TITLE
Controller init

### DIFF
--- a/BasePlugin.py
+++ b/BasePlugin.py
@@ -48,7 +48,6 @@ class Plugin(threading.Thread):
         self.controller_ctor = utils.FindPlugin(self.name, plugin_paths)
         self.ctor_opts = {}
         self.ctor_opts['name'] = self.name
-        self.ctor_opts['initialize'] = True
         self.ctor_opts.update(config_doc['address'])
         if 'additional_params' in config_doc:
             self.ctor_opts.update(config_doc['additional_params'])
@@ -81,6 +80,7 @@ class Plugin(threading.Thread):
             return
         try:
             self.controller = self.controller_ctor(self.ctor_opts)
+            self.controller._Setup()
         except Exception as e:
             self.logger.error('Could not open controller. Error: %s' % e)
             self.controller = None

--- a/ControllerBase.py
+++ b/ControllerBase.py
@@ -16,22 +16,28 @@ class Controller(object):
         opts is a dict with all the options needed for initialization
         (addresses, configuration options, etc)
         """
-        self.logger = logging.getLogger(opts['name'])
         for key, value in opts.items():
             setattr(self, key, value)
+        self.logger = logging.getLogger(self.name)
         self._connected = False
+        self.Setup()
         if self.initialize:
-            if self._getControl():
+            if self.OpenDevice():
                 time.sleep(0.2)
             else:
-                self.logger.error('Something went wrong during initialization...')
+                raise ValueError('Could not properly initialize!')
 
-    def connected(self):
-        return self._connected
-
-    def _getControl(self):
+    def Setup(self, opts):
         """
-        Opens the connection to the device
+        A function for a controller to set its operating parameters (commands, etc).
+        Will be called by the c'tor
+        """
+        pass
+
+    def OpenDevice(self):
+        """
+        Opens the connection to the device. The instance MUST have a _device object
+        after this function returns successfully
         """
         raise NotImplementedError()
 
@@ -50,7 +56,7 @@ class Controller(object):
         """
         raise NotImplementedError()
 
-    def SendRecv(self, message, dev=None):
+    def SendRecv(self, message):
         """
         General controller interface. Returns a dict with retcode -1 if controller not connected,
         -2 if there is an exception, (larger numbers also possible) and whatever data was read. Adds _msg_start and _msg_end
@@ -99,11 +105,8 @@ class SoftwareController(Controller):
         def close():
             return
 
-    def __init__(self, opts):
+    def OpenDevice(self):
         self._device = self.DummyObject()
-        super().__init__(opts)
-
-    def _getControl(self):
         return True
 
     def call(self, command, timeout=1, **kwargs):
@@ -124,17 +127,13 @@ class SerialController(Controller):
     Serial controller class. Implements more direct serial connection specifics
     """
 
-    def __init__(self, opts):
-        self.ttyUSB = -1
+    def OpenDevice(self):
         self._device = serial.Serial()
         self._device.baudrate=9600 if not hasattr(self, 'baud') else self.baud
         self._device.parity=serial.PARITY_NONE
         self._device.stopbits=serial.STOPBITS_ONE
         self._device.timeout=0  # nonblocking mode
         self._device.write_timeout = 5
-        super().__init__(opts)
-
-    def _getControl(self):
         if self.ttyUSB == -1:
             self.logger.error('Could not find device: no ttyUSB')
             return False
@@ -143,14 +142,13 @@ class SerialController(Controller):
             self._device.open()
         except serial.SerialException as e:
             self.logger.error('Problem opening %s: %s' % (self._device.port, e))
-            raise
+            return False
         if not self._device.is_open:
             self.logger.error('Error while connecting to device')
             return False
         else:
             self._connected = True
             return True
-        return False
 
     def isThisMe(self, dev):
         """
@@ -189,29 +187,21 @@ class LANController(Controller):
     Class for LAN-connected controllers
     """
 
-    def __init__(self, opts):
-        self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        super().__init__(opts)
-
-    def _getControl(self):
+    def OpenDevice(self):
         """
         Connects to the controller
         """
-        num_tries = 3
-        for _ in range(num_tries):
-            try:
-                self._device.settimeout(5)
-                self._device.connect((self.ip, int(self.port)))
-            except socket.error as e:
-                self.logger.error('Didn\'t find anything at %s:%i. Trying again in 5 seconds...' % (self.ip, self.port))
-                #sock._device.close()
-                time.sleep(5)
-            else:
-                self._connected = True
-                return True
-        return False
+        self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            self._device.settimeout(5)
+            self._device.connect((self.ip, int(self.port)))
+        except socket.error as e:
+            self.logger.error('Couldn\'t connect to %s:%i' % (self.ip, self.port))
+            return False
+        self._connected = True
+        return True
 
-    def SendRecv(self, message, dev=None):
+    def SendRecv(self, message):
         ret = {'retcode' : 0, 'data' : None}
 
         if not self._connected:

--- a/ControllerBase.py
+++ b/ControllerBase.py
@@ -20,22 +20,23 @@ class Controller(object):
             setattr(self, key, value)
         self.logger = logging.getLogger(self.name)
         self._connected = False
-        self.SetupBeforeOpening()
-        if self.initialize:
-            if self.OpenDevice():
-                self.SetupAfterOpening()
-                time.sleep(0.2)
-            else:
-                raise ValueError('Could not properly initialize!')
+        self.SetParameters()
 
-    def SetupBeforeOpening(self):
+    def _Setup(self):
+        if self.OpenDevice():
+            self.Setup()
+            time.sleep(0.2)
+        else:
+            raise ValueError('Could not properly initialize!')
+
+    def SetParameters(self):
         """
         A function for a controller to set its operating parameters (commands,
         _ms_start token, etc). Will be called by the c'tor
         """
         pass
 
-    def SetupAfterOpening(self):
+    def Setup(self):
         """
         If a controller needs to receive a command after opening but
         before starting "normal" operation, that goes here

--- a/ExampleController.py
+++ b/ExampleController.py
@@ -11,7 +11,7 @@ class ExampleController(SerialController):
     accepted_commands = [
             "a pattern: a description of what this command does",
         ]
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         # Values from the database configuration document are loaded before this
         # function is called. The hardware connection has not been opened yet.
         self._msg_start = ''  # whatever character(s) messages start with
@@ -38,7 +38,7 @@ class ExampleController(SerialController):
                 (re.compile('a pattern'), lambda x : self.commands['set'].format(**x.groupdict())),
                 ]
 
-    def SetupAfterOpening(self):
+    def Setup(self):
         # This function is called after the connection to the hardware is opened
         self.SendRecv(self.commands['prepare'])
 

--- a/ExampleController.py
+++ b/ExampleController.py
@@ -1,74 +1,62 @@
 from BaseController import SerialController  # or LANController, if applicable
 import re  # if you want to accept commands
-import time
+from utils import number_regex  # a regex that matches numbers (ints and floats)
 
 
 class ExampleController(SerialController):
     """
     An example of how to make your own controller
     """
+    # this object is used if you ask for help from the command line
     accepted_commands = [
             "a pattern: a description of what this command does",
-        ] # this object is used if you ask for help from the command line
-    def __init__(self, opts):
+        ]
+    def SetupBeforeOpening(self):
+        # Values from the database configuration document are loaded before this
+        # function is called. The hardware connection has not been opened yet.
         self._msg_start = ''  # whatever character(s) messages start with
         self._msg_end = '\r\n'  # same, for end
         self.commands = {'read' : 'command',
                          'also_read' : 'also_command',
                          'check_id' : 'check_id',
                          'set', 'set_value',
+                         'prepare', 'some_command'
                          }
-        super().__init__(opts)  # calls SerialController.__init__, which calls Controller.__init__
-        # if you need any quantities from the config doc in the command dictionary, call init first
 
+        # this object is a list of the commands for the various readings this
+        # sensor provides.
+        self.reading_commands = [self.commands['read'], self.commands['also_read']]
+
+        # helpful regexes for output handling
+        self.read_pattern = re.compile(bytes('OK;(?P<value>%s)' % number_regex, 'utf-8'))
+        self.error_pattern = re.compile(b'ERR;')
+
+        # this is a list of (regular expression, function) objects. The regular expression
+        # matches the commmand issued via the command line, and the function takes as
+        # argument a re.match object and returns the string to be sent to the controller
         self.command_patterns = [
                 (re.compile('a pattern'), lambda x : self.commands['set'].format(**x.groupdict())),
                 ]
-        # this is a list of (regular expression, function) objects. The regular expression
-        # matches the commmand issued via the command line, and the function takes as
-        # argument a re.match object and returns the string to the sent to the controller
+
+    def SetupAfterOpening(self):
+        # This function is called after the connection to the hardware is opened
+        self.SendRecv(self.commands['prepare'])
 
     def isThisMe(self, dev):
-        """
-        This function checks to see if the device 'dev' is, in fact, this controller.
-        This is only necessary if you inherit from SerialController.
-        """
+        # This function checks to see if the device 'dev' is, in fact, this controller.
+        # This is only necessary if you inherit from SerialController.
         resp = self.SendRecv(self.commands['check_id'], dev)
         if resp['retcode'] or not ret['data']:
             return False
         if resp['data'] == self.some_uniquely_identifying_quantity:
             True
 
-    def Readout(self):
-        """
-        Queries the controller for whatever readings you want. If you only read one value you
-        don't need to make the values into arrays, that will be done upstream
-        """
-        vals = []
-        status = []
-        for coms in ['read','also_read']:
-            resp = self.SendRecv(self.commands[com])
-            if resp['retcode'] or not resp['data']:
-                status.append(resp['retcode'])
-                vals.append(-1)
-            else:
-                status.append(0)
-                vals.append(float(resp['data']))
-        return {'retcode' : status, 'data' : vals}
-
-    def FeedbackReadout(self):
-        """
-        For controllers wishing to be part of a feedback control loop. Should measure
-        only one quantity and return [timestamp, value, status]
-        """
-        resp = self.SendRecv(self.commands['read'])
-        readout_delay = 1.2  # time betwen when we send a command and when we get
-        # the result back, because serial devices are sloooooow
-        # Is this necessary? Probably not, because the device being controlled
-        # gets the updated value sometime within the next second
-        try:
-            value = float(resp['data'])
-        except ValueError, TypeError:
-            value = None
-        return (time.time() - readout_delay, value, resp['retcode'])
+    def ProcessOneReading(self, index, data):
+        # Processes data returned from the sensor. `data` is of type bytes
+        if self.error_pattern.search(data):
+            return -1
+        m = self.read_pattern.search(data)
+        if not m:
+            return -2
+        return float(m.group('value'))
 

--- a/MKS_MFC.py
+++ b/MKS_MFC.py
@@ -11,8 +11,7 @@ class MKS_MFC(SerialController):
             'setpoint <value>: change the setpoint',
             'valve <auto|close|purge>: change valve status',
         ]
-    def __init__(self, opts):
-        super().__init__(opts)
+    def setup(self, opts):
         self._msg_start = f"@@@{self.serialID}"
         self._msg_end = ";FF" # ignores checksum
         self.commands = {'Address' : 'CA',

--- a/MKS_MFC.py
+++ b/MKS_MFC.py
@@ -11,7 +11,7 @@ class MKS_MFC(SerialController):
             'setpoint <value>: change the setpoint',
             'valve <auto|close|purge>: change valve status',
         ]
-    def setup(self, opts):
+    def SetupBeforeOpening(self):
         self._msg_start = f"@@@{self.serialID}"
         self._msg_end = ";FF" # ignores checksum
         self.commands = {'Address' : 'CA',

--- a/MKS_MFC.py
+++ b/MKS_MFC.py
@@ -11,7 +11,7 @@ class MKS_MFC(SerialController):
             'setpoint <value>: change the setpoint',
             'valve <auto|close|purge>: change valve status',
         ]
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_start = f"@@@{self.serialID}"
         self._msg_end = ";FF" # ignores checksum
         self.commands = {'Address' : 'CA',

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -13,7 +13,7 @@ class Teledyne(SerialController):
             'setpoint <value>: change setpoint',
             'valve <auto|open|close>: change valve status',
         ]
-    def setup(self):
+    def SetupBeforeOpening(self):
         self._msg_end = '\r\n'
         self.commands = {
                 'Address' : 'add',

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -13,7 +13,7 @@ class Teledyne(SerialController):
             'setpoint <value>: change setpoint',
             'valve <auto|open|close>: change valve status',
         ]
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_end = '\r\n'
         self.commands = {
                 'Address' : 'add',

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -13,7 +13,7 @@ class Teledyne(SerialController):
             'setpoint <value>: change setpoint',
             'valve <auto|open|close>: change valve status',
         ]
-    def __init__(self, opts):
+    def setup(self):
         self._msg_end = '\r\n'
         self.commands = {
                 'Address' : 'add',
@@ -22,7 +22,6 @@ class Teledyne(SerialController):
                 'Unit' : 'uiu',
                 'SetpointValue' : 'spv'
                 }
-        super().__init__(opts)
         self.device_address = 'a'  # changeable, but default is a
         self.basecommand = f'{self.device_address}' + '{cmd}'
         self.setcommand = self.basecommand + ' {params}'

--- a/caen_n1470.py
+++ b/caen_n1470.py
@@ -18,7 +18,7 @@ class caen_n1470(SerialController):
         '<anode|cathode> vset <value>',
     ]
 
-    def setup(self):
+    def SetupBeforeOpening(self):
         self._msg_start = '$'
         self._msg_end = '\r\n'
         self.commands = {'read' : f'BD:{self.board},' + 'CMD:MON,CH:{ch},PAR:{par}',

--- a/caen_n1470.py
+++ b/caen_n1470.py
@@ -18,8 +18,7 @@ class caen_n1470(SerialController):
         '<anode|cathode> vset <value>',
     ]
 
-    def __init__(self, opts):
-        super().__init__(opts)
+    def setup(self):
         self._msg_start = '$'
         self._msg_end = '\r\n'
         self.commands = {'read' : f'BD:{self.board},' + 'CMD:MON,CH:{ch},PAR:{par}',

--- a/caen_n1470.py
+++ b/caen_n1470.py
@@ -18,7 +18,7 @@ class caen_n1470(SerialController):
         '<anode|cathode> vset <value>',
     ]
 
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_start = '$'
         self._msg_end = '\r\n'
         self.commands = {'read' : f'BD:{self.board},' + 'CMD:MON,CH:{ch},PAR:{par}',

--- a/cryocon_22c.py
+++ b/cryocon_22c.py
@@ -11,7 +11,7 @@ class cryocon_22c(LANController):
             'setpoint <channel> <value>: change the setpoint for the given channel',
             'loop stop: shut down both heaters'
         ]
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_end = ';\n'
         self.commands = { # these are not case sensitive
                 'identify' : '*idn?',

--- a/cryocon_22c.py
+++ b/cryocon_22c.py
@@ -11,7 +11,7 @@ class cryocon_22c(LANController):
             'setpoint <channel> <value>: change the setpoint for the given channel',
             'loop stop: shut down both heaters'
         ]
-    def __init__(self, opts):
+    def setup(self):
         self._msg_end = ';\n'
         self.commands = { # these are not case sensitive
                 'identify' : '*idn?',
@@ -25,7 +25,6 @@ class cryocon_22c(LANController):
                 'settempBUnits' : 'input b:units k',
                 'setSP' : 'loop {ch}:setpt {value}',
                 }
-        super().__init__(opts)
         self.read_pattern = re.compile(b'(?P<value>%s)' % bytes(number_regex, 'utf-8'))
         self.command_patterns = [
                 (re.compile(r'setpoint (?P<ch>1|2) (?P<value>%s)' % number_regex),

--- a/cryocon_22c.py
+++ b/cryocon_22c.py
@@ -11,7 +11,7 @@ class cryocon_22c(LANController):
             'setpoint <channel> <value>: change the setpoint for the given channel',
             'loop stop: shut down both heaters'
         ]
-    def setup(self):
+    def SetupBeforeOpening(self):
         self._msg_end = ';\n'
         self.commands = { # these are not case sensitive
                 'identify' : '*idn?',

--- a/isegNHQ.py
+++ b/isegNHQ.py
@@ -13,13 +13,13 @@ class isegNHQ(SerialController):
             'Ilim <value>: current limit',
             'Vramp <value>: voltage ramp speed',
         ]
-    def __init__(self, opts):
+
+    def setup(self):
         self._msg_end = '\r\n'
         self._msg_start = ''
         self.basecommand = '{cmd}'
         self.setcommand = self.basecommand + '={value}'
         self.getcommand = self.basecommand
-        self.channel = 1
         self.commands = {'open'     : '',
                          'identify' : '#',
                          'Delay'    : 'W',
@@ -36,7 +36,6 @@ class isegNHQ(SerialController):
                          }
         statuses = ['ON','OFF','MAN','ERR','INH','QUA','L2H','H2L','LAS','TRP']
         self.state = dict(zip(statuses,range(len(statuses))))
-        super().__init__(opts)
 
         self.command_patterns = [
                 (re.compile('(?P<cmd>Vset|Itrip|Vramp) +(?P<value>%s)' % number_regex),
@@ -44,14 +43,10 @@ class isegNHQ(SerialController):
                         value=m.group('value'))),
                 ]
 
-
-    def _getControl(self):
-        super()._getControl()
+    def OpenDevice(self):
+        super().OpenDevice()
         self.SendRecv(self.basecommand.format(cmd=self.commands['open']))
-        #self.SendRecv(self.setcommand.format(cmd=self.commands['Delay'],
-        #    value=int(self.delay)))
         return True
-    
 
     def isThisMe(self, dev):
         resp = self.SendRecv(self.commands['open'], dev)

--- a/isegNHQ.py
+++ b/isegNHQ.py
@@ -14,7 +14,7 @@ class isegNHQ(SerialController):
             'Vramp <value>: voltage ramp speed',
         ]
 
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_end = '\r\n'
         self._msg_start = ''
         self.basecommand = '{cmd}'
@@ -43,7 +43,7 @@ class isegNHQ(SerialController):
                         value=m.group('value'))),
                 ]
 
-    def SetupAfterOpening(self):
+    def Setup(self):
         self.SendRecv(self.basecommand.format(cmd=self.commands['open']))
 
     def isThisMe(self, dev):

--- a/isegNHQ.py
+++ b/isegNHQ.py
@@ -14,7 +14,7 @@ class isegNHQ(SerialController):
             'Vramp <value>: voltage ramp speed',
         ]
 
-    def setup(self):
+    def SetupBeforeOpening(self):
         self._msg_end = '\r\n'
         self._msg_start = ''
         self.basecommand = '{cmd}'
@@ -43,10 +43,8 @@ class isegNHQ(SerialController):
                         value=m.group('value'))),
                 ]
 
-    def OpenDevice(self):
-        super().OpenDevice()
+    def SetupAfterOpening(self):
         self.SendRecv(self.basecommand.format(cmd=self.commands['open']))
-        return True
 
     def isThisMe(self, dev):
         resp = self.SendRecv(self.commands['open'], dev)

--- a/iseries.py
+++ b/iseries.py
@@ -9,7 +9,7 @@ class iseries(SerialController):
     iseries controller connection
     """
 
-    def setup(self):
+    def SetupBeforeOpening(self):
         self._msg_start = '*'
         self._msg_end = '\r\n'
         self.commands = {

--- a/iseries.py
+++ b/iseries.py
@@ -9,7 +9,7 @@ class iseries(SerialController):
     iseries controller connection
     """
 
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_start = '*'
         self._msg_end = '\r\n'
         self.commands = {

--- a/iseries.py
+++ b/iseries.py
@@ -9,7 +9,7 @@ class iseries(SerialController):
     iseries controller connection
     """
 
-    def __init__(self, opts):
+    def setup(self):
         self._msg_start = '*'
         self._msg_end = '\r\n'
         self.commands = {
@@ -20,7 +20,6 @@ class iseries(SerialController):
                 'getDisplayedValue' : 'X01',
                 'getCommunicationParameters' : 'R10',
                 }
-        super().__init__(opts)
         self.read_pattern = re.compile(b'%s(?P<value>%s)' % (bytes(self.commands['getDisplayedValue'], 'utf-8'), bytes(number_regex, 'utf-8')))
         self.id_pattern = re.compile(b'%s%s' % (bytes(self.commands['getAddress'], 'utf-8'), bytes(self.serialID, 'utf-8')))
 

--- a/labjack.py
+++ b/labjack.py
@@ -7,12 +7,19 @@ class labjack(Controller):
     Labjack U12. Has a very different interface, so we don't inherit from more
     than Controller
     """
-    def setup(self):
+    def SetupBeforeOpening(self):
         self.analog_channels = list(map(int, self.analog_channels))
         self.digital_channels = list(map(int, self.digital_channels))
 
         self.then = 0
         self.read_args = {'idNum' : None, 'demo' : 0}
+
+    def OpenDevice(self):
+        self._device = u12.U12()
+        return True
+
+    def SetupAfterOpening(self):
+        self.then = self._device.eCount(resetCounter=1)['ms']
 
     def NTCtoTemp(self, val):
         # rc (old) = [5 10e3 8.181e-6 11.67e-6 1000]
@@ -23,11 +30,6 @@ class labjack(Controller):
         #        (self.rc[2]*val)+self.rc[3])/self.rc[4]
         temp = sum([v*resistance**i for i,v in enumerate(self.tc)])
         return temp
-
-    def OpenDevice(self):
-        self._device = u12.U12()
-        self.then = self._device.eCount(resetCounter=1)['ms']
-        return True
 
     def Readout(self):
         voltage = [None]*len(self.analog_channels)

--- a/labjack.py
+++ b/labjack.py
@@ -7,7 +7,7 @@ class labjack(Controller):
     Labjack U12. Has a very different interface, so we don't inherit from more
     than Controller
     """
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self.analog_channels = list(map(int, self.analog_channels))
         self.digital_channels = list(map(int, self.digital_channels))
 
@@ -18,7 +18,7 @@ class labjack(Controller):
         self._device = u12.U12()
         return True
 
-    def SetupAfterOpening(self):
+    def Setup(self):
         self.then = self._device.eCount(resetCounter=1)['ms']
 
     def NTCtoTemp(self, val):

--- a/labjack.py
+++ b/labjack.py
@@ -1,6 +1,5 @@
 from ControllerBase import Controller
 import u12
-import logging
 
 
 class labjack(Controller):
@@ -8,18 +7,12 @@ class labjack(Controller):
     Labjack U12. Has a very different interface, so we don't inherit from more
     than Controller
     """
-    def __init__(self, opts):
-        self.name = opts['name']
-        for k, v in opts.items():
-            setattr(self, k, v)
+    def setup(self):
         self.analog_channels = list(map(int, self.analog_channels))
         self.digital_channels = list(map(int, self.digital_channels))
-        self.logger = logging.getLogger(opts['name'])
-        self._device = u12.U12()
 
         self.then = 0
         self.read_args = {'idNum' : None, 'demo' : 0}
-        self._getControl()
 
     def NTCtoTemp(self, val):
         # rc (old) = [5 10e3 8.181e-6 11.67e-6 1000]
@@ -31,7 +24,8 @@ class labjack(Controller):
         temp = sum([v*resistance**i for i,v in enumerate(self.tc)])
         return temp
 
-    def _getControl(self):
+    def OpenDevice(self):
+        self._device = u12.U12()
         self.then = self._device.eCount(resetCounter=1)['ms']
         return True
 

--- a/pfeiffer_tpg.py
+++ b/pfeiffer_tpg.py
@@ -4,7 +4,7 @@ from utils import number_regex
 
 
 class pfeiffer_tpg(LANController):
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self._msg_begin = ''
         self._msg_end = '\r\n\x05'
         self.commands = {
@@ -13,7 +13,7 @@ class pfeiffer_tpg(LANController):
                 }
         self.read_command = re.compile(b'(?P<status>[0-9]),(?P<value>%s)' % bytes(number_regex, 'utf-8'))
 
-    def SetupAfterOpening(self):
+    def Setup(self):
         self.SendRecv(self.commands['identify'])
         # stops the continuous flow of data
 

--- a/pfeiffer_tpg.py
+++ b/pfeiffer_tpg.py
@@ -4,18 +4,17 @@ from utils import number_regex
 
 
 class pfeiffer_tpg(LANController):
-    def __init__(self, opts):
+    def setup(self, opts):
         self._msg_begin = ''
         self._msg_end = '\r\n\x05'
         self.commands = {
                 'identify' : 'AYT',
                 'read' : 'PR1',
                 }
-        super().__init__(opts)
         self.read_command = re.compile(b'(?P<status>[0-9]),(?P<value>%s)' % bytes(number_regex, 'utf-8'))
 
-    def _getControl(self):
-        super()._getControl()
+    def OpenDevice(self):
+        super().OpenDevice()
         self.SendRecv(self.commands['identify'])
         return True
         # stops the continuous flow of data

--- a/pfeiffer_tpg.py
+++ b/pfeiffer_tpg.py
@@ -4,7 +4,7 @@ from utils import number_regex
 
 
 class pfeiffer_tpg(LANController):
-    def setup(self, opts):
+    def SetupBeforeOpening(self):
         self._msg_begin = ''
         self._msg_end = '\r\n\x05'
         self.commands = {
@@ -13,10 +13,8 @@ class pfeiffer_tpg(LANController):
                 }
         self.read_command = re.compile(b'(?P<status>[0-9]),(?P<value>%s)' % bytes(number_regex, 'utf-8'))
 
-    def OpenDevice(self):
-        super().OpenDevice()
+    def SetupAfterOpening(self):
         self.SendRecv(self.commands['identify'])
-        return True
         # stops the continuous flow of data
 
     def Readout(self):

--- a/smartec_uti.py
+++ b/smartec_uti.py
@@ -8,7 +8,7 @@ class smartec_uti(SerialController):
     Level meter controllers
     """
 
-    def SetupBeforeOpening(self):
+    def SetParameters(self):
         self.commands = {
                 'greet' : '@',
                 'help' : '?',
@@ -24,7 +24,7 @@ class smartec_uti(SerialController):
         self._msg_start = ''
         self._msg_end = '\r\n'
 
-    def SetupAfterOpening(self):
+    def Setup(self):
         self.SendRecv(self.commands['greet'])
         self.SendRecv(self.commands['setSlow'])
         self.SendRecv(self.commands['setMode%s' % int(self.mode)])

--- a/smartec_uti.py
+++ b/smartec_uti.py
@@ -8,7 +8,7 @@ class smartec_uti(SerialController):
     Level meter controllers
     """
 
-    def __init__(self, opts):
+    def setup(self):
         self.commands = {
                 'greet' : '@',
                 'help' : '?',
@@ -23,10 +23,9 @@ class smartec_uti(SerialController):
                 }
         self._msg_start = ''
         self._msg_end = '\r\n'
-        super().__init__(opts)
 
-    def _getControl(self):
-        if not super()._getControl():
+    def OpenDevice(self):
+        if not super().OpenDevice():
             return False
         self.SendRecv(self.commands['greet'])
         self.SendRecv(self.commands['setSlow'])

--- a/smartec_uti.py
+++ b/smartec_uti.py
@@ -8,7 +8,7 @@ class smartec_uti(SerialController):
     Level meter controllers
     """
 
-    def setup(self):
+    def SetupBeforeOpening(self):
         self.commands = {
                 'greet' : '@',
                 'help' : '?',
@@ -24,13 +24,10 @@ class smartec_uti(SerialController):
         self._msg_start = ''
         self._msg_end = '\r\n'
 
-    def OpenDevice(self):
-        if not super().OpenDevice():
-            return False
+    def SetupAfterOpening(self):
         self.SendRecv(self.commands['greet'])
         self.SendRecv(self.commands['setSlow'])
         self.SendRecv(self.commands['setMode%s' % int(self.mode)])
-        return True
 
     def isThisMe(self, dev):
         """

--- a/utils.py
+++ b/utils.py
@@ -152,7 +152,6 @@ def refreshTTY(db):
     for sensor in sensor_names:
         opts = {}
         opts['name'] = sensor
-        opts['initialize'] = False
         opts.update(sensor_config[sensor]['address'])
         if 'additional_params' in sensor_config[sensor]:
             opts.update(sensor_config[sensor]['additional_params'])


### PR DESCRIPTION
The old method of endless calls of `super().__init__` in controller drivers is a terrible solution, as there wasn't a consistent order between this call and controller-specific stuff. This PR solves this by adding `SetupBeforeOpening` and `SetupAfterOpening` prototypes for controllers to reinstance, which is code to be executed before or after opening the connection to the device. `SetupBeforeOpening` is called after values from the database are loaded, so this function will have access to that information.