### PR TITLE
No more arrays

### DIFF
--- a/BasePlugin.py
+++ b/BasePlugin.py
@@ -51,7 +51,7 @@ class Plugin(threading.Thread):
         self.process_queue = queue.Queue()
         self.buffer_thread = None
         self.buffer_lock = threading.Rlock()
-        self.buffer = [], []
+        self.buffer = []
         self.sh = utils.SignalHandler(self.logger)
         self.logger.debug('Started')
 
@@ -95,10 +95,10 @@ class Plugin(threading.Thread):
         """
         self.OpenSensor()
         self.buffer_thread = threading.Thread(target=self.Bufferer)
-        for key in self.reading_names:
-            t = threading.Thread(target=self.ReadoutLoop, args=(key, ))
+        for name in self.reading_names:
+            t = threading.Thread(target=self.ReadoutLoop, args=(name, ))
             t.start()
-            self.readout_threads[key] = t
+            self.readout_threads[name] = t
             time.sleep(0.1)
         self.logger.debug('Running...')
         while not self.sh.interrupted:
@@ -139,7 +139,7 @@ class Plugin(threading.Thread):
         """
         A loop that puts readout commands into the Sensor's readout queue
 
-        :param reading_key: the key of the reading that this loop handles
+        :param reading_name: the name of the reading that this loop handles
         """
         while not self.sh.interrupted:
             loop_start_time = time.time()

--- a/BasePlugin.py
+++ b/BasePlugin.py
@@ -144,6 +144,8 @@ class Plugin(threading.Thread):
         while not self.sh.interrupted:
             loop_start_time = time.time()
             reading = self.db.GetReading(sensor=self.name, name=reading_name)
+            if reading['readout_interval'] <= 0:
+                break
             if reading['status'] == 'online' and self._connected:
                 self.sensor.AddToSchedule(reading_name=reading_name,
                                           callback=self.ProcessReading)

--- a/BasePlugin.py
+++ b/BasePlugin.py
@@ -45,21 +45,23 @@ class Plugin(threading.Thread):
         self.last_measurement_time = time.time()
         self.sensor = None
         self.OpenSensor()
-        self.running = False
         self.has_quit = False
-        self.reading_keys = config_doc['readings']
-        self.readout_threads = []
+        self.reading_names = config_doc['readings']
+        self.readout_threads = {}
         self.process_queue = queue.Queue()
-        self.reading_lock = threading.RLock()
+        self.buffer_thread = None
+        self.buffer_lock = threading.Rlock()
+        self.buffer = [], []
         self.sh = utils.SignalHandler(self.logger)
         self.logger.debug('Started')
 
     def close(self):
         """Closes the sensor"""
         self.logger.debug('Beginning shutdown')
-        self.running = False
-        for t in self.readout_threads:
+        self.sh.interrupted = True
+        for t in self.readout_threads.values():
             t.join()
+        self.buffer_thread.join()
         if not self.sensor:
             return
         self.sensor.close()
@@ -89,20 +91,19 @@ class Plugin(threading.Thread):
         new commands, and repeats until told to quit. Closes the sensor when finished
         """
         self.OpenSensor()
-        self.running = True
-        for key in self.reading_keys:
-            self.readout_threads.append(threading.Thread(
-                target=self.ReadoutLoop,
-                args=(key,)))
-            self.readout_threads[-1].start()
+        self.buffer_thread = threading.Thread(target=self.Bufferer)
+        for key in self.reading_names:
+            t = threading.Thread(target=self.ReadoutLoop, args=(key, ))
+            t.start()
+            self.readout_threads[key] = t
             time.sleep(0.1)
         self.logger.debug('Running...')
-        while self.running and not self.sh.interrupted:
+        while not self.sh.interrupted:
             self.logger.debug('Top of main loop')
             loop_start_time = time.time()
             self.HandleCommands()
             loop_until = utils.heartbeat_timer + loop_start_time
-            while time.time() < loop_until and self.running:
+            while time.time() < loop_until and not self.sh.interrupted:
                 try:
                     packet = self.process_queue.get_nowait()
                 except queue.Empty:
@@ -124,7 +125,7 @@ class Plugin(threading.Thread):
                                     pass
                                 finally:
                                     self.sensor = None
-                                    self.running = False
+                                    self.sh.interrupted = True
                                     break
                             else:
                                 self.logger.info('Reconnected successfully')
@@ -150,38 +151,63 @@ class Plugin(threading.Thread):
         self.HandleCommands()
         return
 
-    def ReadoutLoop(self, reading_key):
+    def Bufferer(self):
+        """
+        Empties the buffer into the database periodically
+        """
+        while not self.sh.interrupted:
+            loop_start_time = time.time()
+            with self.buffer_lock:
+                if len(self.buffer[0]):
+                    doc = dict(self.buffer)
+                    self.logger.debug('%i readings, %i values' % (len(doc), len(self.buffer)))
+                    self.db.WriteDataToDatabase(self.name, doc)
+                    self.buffer = []
+                else:
+                    self.logger.debug('No data in buffer')
+            wait_until = loop_start_time + utils.buffer_time
+            while time.time() < wait_until and not self.sh.interrupted:
+                time.sleep(1)
+
+    def BufferData(self, reading_name, value):
+        """
+        Adds data to the storage buffer
+        """
+
+    def ReadoutLoop(self, reading_name):
         """
         A loop that puts readout commands into the Sensor's readout queue
 
         :param reading_key: the key of the reading that this loop handles
         """
-        while self.running and not self.sh.interrupted:
+        while not self.sh.interrupted:
             loop_start_time = time.time()
-            reading = self.db.GetReading(key=reading_key)
+            reading = self.db.GetReading(sensor=self.name, name=reading_name)
             if reading['status'] == 'online' and self._connected:
-                self.sensor.AddToSchedule(reading_name=reading['name'],
-                        callback=self.process_queue.put)
+                self.sensor.AddToSchedule(reading_name=reading_name,
+                                          callback=self.ProcessReading)
             sleep_until = loop_start_time + reading['readout_interval']
             now = time.time()
-            while self.running and not self.sh.interrupted and now < sleep_until:
+            while not self.sh.interrupted and now < sleep_until:
                 time.sleep(min(1, sleep_until - now))
                 now = time.time()
-        self.logger.debug('Loop "%s" returning' % reading_key)
+        self.logger.debug('Loop "%s" returning' % reading_name)
 
-    def ProcessReading(self, index, timestamp, value, retcode):
+    def ProcessReading(self, rd_name, value, retcode):
         """
         Checks data for warning/alarms and writes it to the database
 
-        :param index: the index of the reading to process
-        :param timestamp: unix timestamp of when the value was recorded
+        :param rd_name: the name of the reading to process
         :param value: the value the sensor returns
         :param retcode: the status code the sensor returns
         """
-        self.logger.debug('Processing (%i %s %i)' % (index, value, retcode))
-        runmode = self.runmode
-        reading = self.readings[index]
-        message_time = self.db.getDefaultSettings(runmode=runmode,name='message_time')
+        self.logger.debug('Processing (%s %s %i)' % (rd_name, value, retcode))
+        reading = db.GetReading(self.name, rd_name)
+        runmode = reading['runmode']
+        if rd_name not in self.status_counter:
+            self.status_counter[rd_name] = 0
+            self.recurrence_counter[rd_name] = 0
+        message_time = self.db.getDefaultSettings(runmode=runmode, name='message_time')
         readout_interval = reading['readout_interval']
         dt = (dtnow() - self.last_message_time).total_seconds()
         too_soon = (dt < message_time*60)
@@ -189,44 +215,45 @@ class Plugin(threading.Thread):
         alarm_ranges = reading['alarms']
         if alarm_level > -1:
             if retcode < 0:
-                self.status_counter[index] += 1
-                if self.status_counter[index] >= 3 and not too_soon:
+                self.status_counter[rd_name] += 1
+                if self.status_counter[rd_name] >= 3 and not too_soon:
                     msg = f'Something wrong? Status {index} is {retcode}'
                     self.logger.warning(msg)
-                    self.db.logAlarm({'name' : self.name, 'index' : index,
+                    self.db.logAlarm({'name' : self.name, 'reading' : rd_name,
                             'when' : when, 'status' : retcode,
                             'reason' : 'status', 'howbad' : 0, 'msg' : msg})
-                    self.status_counter[index] = 0
+                    self.status_counter[rd_name] = 0
                     self.last_message_time = dtnow()
             else:
-                self.status_counter[index] = 0
+                self.status_counter[rd_name] = 0
             try:
                 levels_to_check = list(range(alarm_level, len(alarm_ranges)))[::-1]
                 for j in levels_to_check:
                     lo, hi = alarm_ranges[j]
                     if clip(value, lo, hi) in [lo, hi]:
-                        self.recurrence_counter[index] += 1
-                        if self.recurrence_counter[index] >= reading['recurrence'] and not too_soon:
-                            msg = (f"Reading {index} ({reading['description']}, value "
+                        self.recurrence_counter[rd_name] += 1
+                        if self.recurrence_counter[rd_name] >= reading['recurrence'] and not too_soon:
+                            msg = (f"Reading {rd_name} ({reading['description']}, value "
                                f'{value:.3g}) is outside the level {j} alarm range '
                                f'({lo:.3g}, {hi:.3g})')
-                            self.logger.critical(msg)
-                            self.db.logAlarm({'name' : self.name, 'index' : index,
+                            self.logger.warning(msg)
+                            self.db.logAlarm({'name' : self.name, 'rd_name' : rd_name,
                                 'when' : dtnow(), 'data' : value,
                                 'reason' : 'alarm', 'howbad' : j, 'msg' : msg})
-                            self.recurrence_counter[index] = 0
+                            self.recurrence_counter[rd_name] = 0
                             self.last_message_time = dtnow()
                     break
                 else:
-                    self.recurrence_counter[index] = 0
+                    self.recurrence_counter[rd_name] = 0
             except Exception as e:
-                self.logger.critical(f"Could not check reading {index} ({reading['description']}): {e} ({str(type(e))})")
+                self.logger.error(f"Could not check reading {rd_name} "
+                    f"({reading['description']}): {e} ({str(type(e))})")
         if value is None:
             return
-        time_diff = timestamp - self.last_measurement_time
-        if time_diff > 3*reading['readout_interval']:
+        time_diff = time.time() - self.last_measurement_time
+        if time_diff > 1.5*max(reading['readout_interval'], utils.heartbeat_timer):
             self.late_counter += 1
-            if self.late_counter >= 3 and not too_soon:
+            if self.late_counter >= 2 and not too_soon:
                 msg = f'Sensor responding slowly?'
                 self.logger.warning(msg)
                 self.db.logAlarm({'name' : self.name, 'when' : dtnow(),
@@ -235,10 +262,9 @@ class Plugin(threading.Thread):
                 self.late_counter = 0
         else:
             self.late_counter = 0
-        self.last_measurement_time = timestamp
-        collection_name = '%s__%s' % (self.name, reading['name'])
-        when = datetime.datetime.fromtimestamp(timestamp)
-        self.db.writeDataToDatabase(collection_name, when, value)
+        self.last_measurement_time = time.time()
+        with self.buffer_lock:
+            self.buffer.append((rd_name, value))
 
     def HandleCommands(self):
         """
@@ -254,7 +280,7 @@ class Plugin(threading.Thread):
                 loglevel = self.db.getDefaultSettings(runmode=runmode,name='loglevel')
                 self.logger.setLevel(int(loglevel))
             elif command == 'stop':
-                self.running = False
+                self.sh.interrupted = True
                 self.has_quit = True
                 # makes sure we don't get restarted
             elif command == 'wake':

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -463,27 +463,30 @@ class DobermanDB(object):
         doc = self.GetSensorSettings(sensor_name)
         return doc[field]
 
-    def GetReading(self, key=None):
+    def GetReading(self, sensor=None, name=None):
         """
         Gets the document from one reading
 
-        :param key: the reading's key. Default 'None'
+        :param sensor: the name of the sensor
+        :param name: the name of the reading
         :returns: reading document
         """
-        return self.readFromDatabase('settings', 'readings', cuts={'key' : key},
-                onlyone=True)
+        return self.readFromDatabase('settings', 'readings',
+                cuts={'sensor' : sensor, 'name' : name}, onlyone=True)
 
-    def UpdateReading(self, key=None, field=None, value=None):
+    def UpdateReading(self, sensor=None, name=None, field=None, value=None):
         """
         Updates a parameter for a reading
 
-        :param key: the reading's key
+        :param sensor: the name of the sensor
+        :param name: the name of the reading
         :param field: the specific field to update
         :param value: the new value
         """
         if key is None:
             key = '%s__%s' % (sensor_name, reading_name)
-        self.updateDatabase('settings', 'readings', cuts={'key' : key},
+        self.updateDatabase('settings', 'readings',
+                cuts={'sensor' : sensor, 'name' : name},
                 updates={'$set' : {field : value}})
 
     def SetSensorSetting(self, name, field, value):
@@ -507,7 +510,7 @@ class DobermanDB(object):
         """
         if runmode:
             doc = self.readFromDatabase('settings','runmodes',
-                    {'mode' : runmode},onlyone=True)
+                    {'mode' : runmode}, onlyone=True)
             if name:
                 return doc[name]
             return doc
@@ -581,20 +584,18 @@ class DobermanDB(object):
         print()
         return 0
 
-    def writeDataToDatabase(self, collection_name, when, value):
+    def WriteDataToDatabase(self, sensor_name, data_doc):
         """
         Writes data to the database
 
-        :param collection_name: <sensor name>__<reading name>
-        :param when: datetime instance of reading timestamp
-        :param value: the actual value to insert
+        :param sensor_name: the name of the sensor
+        :param data_doc: the document with data
         :returns 0 on success, -1 otherwise
         """
-        ret = self.insertIntoDatabase('data', collection_name,
-                {'when' : when, 'data' : value})
+        ret = self.insertIntoDatabase('data', sensor_name, data_doc)
         if ret:
             self.logger.warning("Can not write data from %s to Database. "
-                                "Database interaction error." % collection_name)
+                                "Database interaction error." % sensor_name)
             return -1
         return 0
 

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -1,4 +1,4 @@
-#!/scratch/anaconda3/bin/python3
+#!/usr/bin/env python3
 import logging
 import datetime
 import pymongo
@@ -449,7 +449,8 @@ class DobermanDB(object):
         :param name: the name of the sensor
         :returns: configuration document for the specified sensor
         """
-        return self.readFromDatabase('settings', 'sensors', cuts={'name' : name}, onlyone=True)
+        return self.readFromDatabase('settings', 'sensors', cuts={'name' : name},
+                onlyone=True)
 
     def GetSensorSetting(self, sensor_name, field):
         """
@@ -462,16 +463,28 @@ class DobermanDB(object):
         doc = self.GetSensorSettings(sensor_name)
         return doc[field]
 
-    def GetReading(self, sensor_name, reading_name):
+    def GetReading(self, key=None):
         """
         Gets the document from one reading
 
-        :param sensor_name: the name of the sensor
-        :param reading_name: the name of the reading
+        :param key: the reading's key. Default 'None'
         :returns: reading document
         """
-        doc = self.GetSensorSettings(sensor_name)
-        return doc['readings'][reading_name]
+        return self.readFromDatabase('settings', 'readings', cuts={'key' : key},
+                onlyone=True)
+
+    def UpdateReading(self, key=None, field=None, value=None):
+        """
+        Updates a parameter for a reading
+
+        :param key: the reading's key
+        :param field: the specific field to update
+        :param value: the new value
+        """
+        if key is None:
+            key = '%s__%s' % (sensor_name, reading_name)
+        self.updateDatabase('settings', 'readings', cuts={'key' : key},
+                updates={'$set' : {field : value}})
 
     def SetSensorSetting(self, name, field, value):
         """
@@ -481,7 +494,7 @@ class DobermanDB(object):
         :param field: the specific field to update
         :param value: the new value
         """
-        self.updateDatabase('settings','sensors',cuts={'name' : name},
+        self.updateDatabase('settings', 'sensors', cuts={'name' : name},
                 updates = {'$set' : {field : value}})
 
     def getDefaultSettings(self, runmode=None, name=None):

--- a/DobermanDB.py
+++ b/DobermanDB.py
@@ -447,9 +447,31 @@ class DobermanDB(object):
         Reads the settings in the database.
 
         :param name: the name of the sensor
-        :returns configuration document for the specified sensor
+        :returns: configuration document for the specified sensor
         """
         return self.readFromDatabase('settings', 'sensors', cuts={'name' : name}, onlyone=True)
+
+    def GetSensorSetting(self, sensor_name, field):
+        """
+        Gets a specific setting from one sensor
+
+        :param sensor_name: the name of the sensor
+        :param field: the field you want
+        :returns: the value of the named field
+        """
+        doc = self.GetSensorSettings(sensor_name)
+        return doc[field]
+
+    def GetReading(self, sensor_name, reading_name):
+        """
+        Gets the document from one reading
+
+        :param sensor_name: the name of the sensor
+        :param reading_name: the name of the reading
+        :returns: reading document
+        """
+        doc = self.GetSensorSettings(sensor_name)
+        return doc['readings'][reading_name]
 
     def SetSensorSetting(self, name, field, value):
         """
@@ -694,6 +716,12 @@ class DobermanDB(object):
             else:
                 print('Sensor added')
         return
+
+    def GetCurrentStatus(self):
+        """
+        Gives a snapshot of the current system status
+        """
+        pass
 
     def CurrentStatus(self):
         """

--- a/ExampleSensor.py
+++ b/ExampleSensor.py
@@ -23,12 +23,13 @@ class ExampleSensor(SerialSensor):
                          'prepare', 'some_command'
                          }
 
-        # this object is a list of the commands for the various readings this
+        # this object is a dict of the commands for the various readings this
         # sensor provides.
-        self.reading_commands = [self.commands['read'], self.commands['also_read']]
+        self.reading_commands = {zip(['cmd_name_0', 'cmd_name_1'],
+                                     [self.commands['read'], self.commands['also_read'])}
 
         # helpful regexes for output handling
-        self.read_pattern = re.compile(bytes('OK;(?P<value>%s)' % number_regex, 'utf-8'))
+        self.reading_pattern = re.compile(('OK;(?P<value>%s)' % number_regex).encode())
         self.error_pattern = re.compile(b'ERR;')
 
         # this is a list of (regular expression, function) objects. The regular expression

--- a/MKS_MFC.py
+++ b/MKS_MFC.py
@@ -49,8 +49,10 @@ class MKS_MFC(SerialSensor):
         self._NAK = 'NAK'
         self.nak_pattern = re.compile(f'{self._NAK}(?P<errcode>[^;]+);')
         self.ack_pattern = re.compile(f'{self._ACK}(?P<value>[^;]+);')
-        self.reading_commands = [self.getCommand.format(cmd=self.commands[com])
-            for com in ['FlowRate','FlowRatePercent','InternalTemperature']]
+        self.reading_commands = {
+                'flow' : self.getCommand.format(cmd=self.commands['FlowRate']),
+                'flow_pct' : self.getCommand.format(cmd=self.commands['FlowRatePercent']),
+                'temp' : self.getCommand.format(cmd=self.commands['InternalTemperature'])}
         self.setpoint_map = {'auto' : 'NORMAL', 'purge' : 'PURGE', 'close' : 'FLOW_OFF'}
         self.command_patterns = [
                 (re.compile(r'setpoint (?P<value>%s)' % number_regex),
@@ -69,7 +71,7 @@ class MKS_MFC(SerialSensor):
             return True
         return False
 
-    def ProcessOneReading(self, index, data):
+    def ProcessOneReading(self, name, data):
         m = self.nak_pattern.search(data)
         if m:
             return -1*int(m.group('value'))

--- a/Teledyne.py
+++ b/Teledyne.py
@@ -27,13 +27,13 @@ class Teledyne(SerialSensor):
         self.setcommand = self.basecommand + ' {params}'
         self.getcommand = self.basecommand + '?'
 
-        self.get_reading = re.compile(b'READ:(?P<value>%s)' % bytes(number_regex, 'utf-8'))
+        self.reading_pattern = re.compile(('READ:(?P<value>%s)' % number_regex).encode())
         self.get_addr = re.compile(b'ADDR: *(?P<addr>[a-z])')
         self.command_echo = f'\\*{self.device_address}\\*:' + '{cmd} *;'
         self.retcode = f'!{self.device_address}!(?P<retcode>[beow])!'
 
         self.setpoint_map = {'auto' : 0, 'open' : 1, 'close' : 2}
-        self.reading_commands = [self.commands['read']]
+        self.reading_commands = {'flow' : self.commands['read']}
         self.command_patterns = [
                 (re.compile(r'setpoint (?P<params>%s)' % number_regex),
                     lambda x : self.setcommand.format(cmd=self.commands['SetpointValue'],
@@ -54,10 +54,4 @@ class Teledyne(SerialSensor):
         if self.device_address != m.group('addr').decode():
             return False
         return True
-
-    def ProcessOneReading(self, index, data):
-        m = self.get_reading.search(data)
-        if not m:
-            return None
-        return float(m.group('value'))
 

--- a/cryocon_22c.py
+++ b/cryocon_22c.py
@@ -25,8 +25,15 @@ class cryocon_22c(LANSensor):
                 'settempBUnits' : 'input b:units k',
                 'setSP' : 'loop {ch}:setpt {value}',
                 }
-        self.read_pattern = re.compile(b'(?P<value>%s)' % bytes(number_regex, 'utf-8'))
-        self.reading_commands = [self.commands[x] for x in ['getTempA','getTempB','getSP1','getSP2','getLp1Pwr','getLp2Pwr']]
+        self.reading_pattern = re.compile(('(?P<value>%s)' % number_regex).encode())
+        self.reading_commands = {
+                'cf_temp_top' : self.commands['getTempA'],
+                'cf_temp_bot' : self.commands['getTempB'],
+                'setpt1' : self.commands['getSP1'],
+                'setpt2' : self.commands['getSP2'],
+                'heater1' : self.commands['getLp1Pwr'],
+                'heater2' : self.commands['getLp2Pwr']
+                }
         self.command_patterns = [
                 (re.compile(r'setpoint (?P<ch>1|2) (?P<value>%s)' % number_regex),
                     lambda x : self.commands['setSP'].format(**x.groupdict())),
@@ -38,7 +45,4 @@ class cryocon_22c(LANSensor):
         if 'missiles' in m.group(0):
             self.logger.warning('But I am leh tired...')
         return 'stop'
-
-    def ProcessOneReading(self, index, data):
-        return float(self.read_pattern.search(data).group('value'))
 

--- a/cryocon_26.py
+++ b/cryocon_26.py
@@ -2,6 +2,7 @@ from cryocon_22c import cryocon_22c
 
 
 class cryocon_26(cryocon_22c):
-    def __init__(self, opts):
-        super().__init__(opts)
-        self.reading_commands = [f'input? {ch}:units k' for ch in 'abcd']
+    def SetParameters(self):
+        super().SetParameters()
+        self.reading_commands = {zip(['tempA','tempB','tempC','tempD'],
+                                     [f'input? {ch}:units k' for ch in 'abcd'])}

--- a/isegNHQ.py
+++ b/isegNHQ.py
@@ -36,7 +36,7 @@ class isegNHQ(SerialSensor):
                          }
         statuses = ['ON','OFF','MAN','ERR','INH','QUA','L2H','H2L','LAS','TRP']
         self.state = dict(zip(statuses,range(len(statuses))))
-        self.reading_commands = [self.commands[x] for x in ['Current','Voltage','Vset','Status']]
+        self.reading_commands = {s.lower:self.commands[s] for s in ['Current','Voltage','Vset','Status']}
 
         self.command_patterns = [
                 (re.compile('(?P<cmd>Vset|Itrip|Vramp) +(?P<value>%s)' % number_regex),

--- a/iseries.py
+++ b/iseries.py
@@ -20,9 +20,9 @@ class iseries(SerialSensor):
                 'getDisplayedValue' : 'X01',
                 'getCommunicationParameters' : 'R10',
                 }
-        self.read_pattern = re.compile(b'%s(?P<value>%s)' % (bytes(self.commands['getDisplayedValue'], 'utf-8'), bytes(number_regex, 'utf-8')))
-        self.reading_commands = [self.commands['getDisplayedValue']]
-        self.id_pattern = re.compile(b'%s%s' % (bytes(self.commands['getAddress'], 'utf-8'), bytes(self.serialID, 'utf-8')))
+        self.reading_pattern = re.compile(('%s(?P<value>%s)' % (self.commands['getDisplayedValue'], number_regex)).encode())
+        self.reading_commands = {self.reading_names[0]:self.commands['getDisplayedValue']}
+        self.id_pattern = re.compile(('%s%s' % (self.commands['getAddress'], self.serialID)).encode())
 
     def isThisMe(self, dev):
         info = self.SendRecv(self.commands['getAddress'], dev)
@@ -36,10 +36,4 @@ class iseries(SerialSensor):
                 return True
         except:
             return False
-
-    def ProcessOneReading(self, index, data):
-        m = self.read_pattern.search(data)
-        if not m:
-            return None
-        return float(m.group('value'))
 

--- a/labjack.py
+++ b/labjack.py
@@ -1,10 +1,6 @@
 from SensorBase import Sensor
 import u12
-<<<<<<< HEAD
-=======
-import logging
 import time
->>>>>>> a5a4c8479b2709631910e74f3fc91e85d1f349f9
 
 
 class labjack(Sensor):
@@ -31,7 +27,7 @@ class labjack(Sensor):
         temp = sum([v*resistance**i for i,v in enumerate(self.tc)])
         return temp
 
-    def AddToSchedule(self, reading_index=None, command=None, callback=None):
+    def AddToSchedule(self, reading_name=None, command=None, callback=None):
         """
         The labjack doesn't have a SendRecv interface, so we can't
         rely on the framework for other sensors here. As the labjack
@@ -39,15 +35,17 @@ class labjack(Sensor):
         `ReadoutScheduler`, `AddToSchedule` (the only thing actually called from
         the owning Plugin), `_ProcessReading`, and `ProcessOneReading`
         """
-        if index == 0:  # bias volate
+        value = None
+        retcode = 1
+        if reading_name == 'vbias':  # bias voltage
             v = self._device.eAnalogIn(channel=2, gain=0, **self.read_args)
             value = v['voltage']
             retcode = 0
-        elif index == 1:  # glovebox temperature
+        elif reading_name == 'box_temp':  # glovebox temperature
             v = self._devide.eAnalogIn(channel=0, gain=0, **self.read_args)
             value = self.NTCtoTemp(v['voltage'])
             retcode = 0
-        elif index == 2:  # MV frequency
+        elif reading_name == 'mv_freq':  # MV frequency
             count = self._device.eCount(resetCounter=1)
             counts = count['count']
             now = count['ms']
@@ -58,12 +56,12 @@ class labjack(Sensor):
                 value = counts/(now - self.then)*1000
                 self.then = now
                 retcode = 0
-        elif index == 3:  # valve sensors
+        elif reading_name == 'valve_sens':  # valve sensors
             v = self._device.eDigitalIn(channel=0, readD=0, **self.read_args)
             value = v['state']
             retcode = 0
-        elif index == 4:  # nitrogen valve state
+        elif reading_name == 'valve_state':  # nitrogen valve state
             v = self._device.eDigitalIn(channel=1, readD=0, **self.read_args)
             value = v['state']
             retcode = 0
-        callback((index, time.time(), value, retcode))
+        callback((reading_name, time.time(), value, retcode))

--- a/pfeiffer_tpg.py
+++ b/pfeiffer_tpg.py
@@ -11,16 +11,10 @@ class pfeiffer_tpg(LANSensor):
                 'identify' : 'AYT',
                 'read' : 'PR1',
                 }
-        self.reading_commands = [self.commands['read']]
-        self.read_command = re.compile(b'(?P<status>[0-9]),(?P<value>%s)' % bytes(number_regex, 'utf-8'))
+        self.reading_commands = {'iso_pressure' : self.commands['read']}
+        self.reading_pattern = re.compile(('(?P<status>[0-9]),(?P<value>%s)' % number_regex).encode())
 
     def Setup(self):
         self.SendRecv(self.commands['identify'])
         # stops the continuous flow of data
-
-    def ProcessOneReading(self, index, data):
-        m = self.read_command.search(data)
-        if not m:
-            return None
-        return float(m.group('value'))
 

--- a/smartec_uti.py
+++ b/smartec_uti.py
@@ -1,6 +1,7 @@
 from SensorBase import SerialSensor
 from subprocess import Popen, PIPE, TimeoutExpired
 import re  # EVERYBODY STAND BACK
+from itertools import repeat
 
 
 class smartec_uti(SerialSensor):
@@ -24,6 +25,8 @@ class smartec_uti(SerialSensor):
         self._msg_start = ''
         self._msg_end = '\r\n'
         self.reading_commands = [self.commands['measure']]*3  # handles all cases
+        self.reading_commands = dict(zip(self.reading_names,
+                                         repeat(self.commands['measure'])))
 
     def Setup(self):
         self.SendRecv(self.commands['greet'])
@@ -67,7 +70,7 @@ class smartec_uti(SerialSensor):
             return True
         return False
 
-    def ProcessOneReading(self, index, data):
+    def ProcessOneReading(self, name, data):
         """
         """
         values = data.decode().rstrip().split()
@@ -80,6 +83,6 @@ class smartec_uti(SerialSensor):
             resp = [(v-c_off)/div*self.c_ref for v in values[2:]]
             if len(resp) > 1:
                 return resp
-            return resp[index]
+            return resp[0]
         return None
 

--- a/sonar.py
+++ b/sonar.py
@@ -1,22 +1,22 @@
 from BaseSensor import SoftwareSensor
 import re  # EVERYBODY STAND BACK xkcd.com/208
 from utils import number_regex
+from itertools import repeat
 
 
 class sonar(SoftwareSensor):
     """
     Sensor that pings another machine to see if it is alive
     """
-    def __init__(self, opts):
-        super().__init__(opts)
+    def SetParameters(self):
         value_count = 4  # number of values returned
-        self.reading_commands = [f'ping -c 3 -W 5 {self.address}']*value_count
+        self.reading_commands = dict(zip(self.reading_names, repeat(f'ping -c 3 -W 5 {self.address}')))
         packet_loss_pattern = '(?P<loss>%s)%% packet loss' % number_regex
-        self.packet_loss = re.compile(bytes(packet_loss_pattern, 'utf-8'))
+        self.packet_loss = re.compile(packet_loss_pattern.encode())
         time_pattern = '(?P<min>{0})/(?P<avg>{0})/(?P<max>{0})/(?P<mdev>{0}) ms'.format(0=number_regex)
-        self.time_taken = re.compile(bytes(time_pattern, 'utf-8'))
+        self.time_taken = re.compile(time_pattern.encode())
 
-    def ProcessOneReading(self, index, data):
+    def ProcessOneReading(self, name, data):
         m = self.packet_loss.search(data)
         if not m:
             return None

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,7 @@ dtnow = datetime.datetime.now
 
 
 heartbeat_timer = 300
+buffer_timer = 5
 number_regex = r'[\-+]?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
 doberman_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 

--- a/utils.py
+++ b/utils.py
@@ -11,7 +11,7 @@ import inspect
 dtnow = datetime.datetime.now
 
 
-heartbeat_timer = 30
+heartbeat_timer = 300
 number_regex = r'[\-+]?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
 doberman_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 


### PR DESCRIPTION
Rather than remembering which reading corresponds to which index, it's much better to have them as dicts which can be referenced by name and not index.

Additionally, the data storage format is changed. A plugin will buffer all its data for `utils.buffer_timer` seconds, then assemble those into a single document to be inserted into the database (with objectid as the timestamp). Duplicate values from one reading are ignored; only the most recent is taken. This means that a reading with a readout interval faster than the buffer timer will not record data more frequently, and that all measurements will have an uncertainty on the actual measurement time of half the buffer timer.

Readings are now stored as individual documents in a separate collection to simplify the threadsafe-ness of access.