### PR TITLE
Drift not quite enough

### DIFF
--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -136,7 +136,7 @@ class InfluxSourceNode(SourceNode):
         self.req_params = params
         self.last_time = 0
 
-    def get_package(self):
+    def get_package(self, recurse=True):
         response = requests.get(self.req_url, headers=self.req_headers, params=self.req_params)
         try:
             timestamp, val = response.content.decode().splitlines()[1].split(',')[-2:]
@@ -146,6 +146,9 @@ class InfluxSourceNode(SourceNode):
         timestamp = int(timestamp)
         val = float(val) # 53 bits of precision and we only ever have small integers
         if self.last_time == timestamp and not self.accept_old:
+            if recurse:
+                # try again
+                return self.get_package(recurse=False)
             raise ValueError(f'{self.name} didn\'t get a new value for {self.input_var}!')
         self.last_time = timestamp
         self.logger.debug(f'{self.name} time {timestamp} value {val}')

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -46,29 +46,29 @@ class PipelineMonitor(Doberman.Monitor):
 
     def process_command(self, command):
         try:
-            if command == 'pipelinectl_start':
+            if command.startswith('pipelinectl_start'):
                 _, name = command.split(' ')
                 self.start_pipeline(name)
-            elif command == 'pipelinectl_stop':
+            elif command.startswith('pipelinectl_stop'):
                 _, name = command.split(' ')
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
                     self.stop_pipeline(name)
-            elif command == 'pipelinectl_restart':
+            elif command.startswith('pipelinectl_restart'):
                 _, name = command.split(' ')
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
                     self.stop_pipeline(name)
                     self.start_pipeline(name)
-            elif command == 'pipelinectl_silent':
+            elif command.startswith('pipelinectl_silent'):
                 _, name = command.split(' ')
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
                     self.db.set_pipeline_value(name, [('status', 'silent')])
-            elif command == 'pipelinectl_active':
+            elif command.startswith('pipelinectl_active'):
                 _, name = command.split(' ')
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
@@ -76,6 +76,7 @@ class PipelineMonitor(Doberman.Monitor):
                     self.db.set_pipeline_value(name, [('status', 'active')])
             elif command == 'stop':
                 self.sh.event.set()
-                return
+            else:
+                self.logger.info(f'I don\'t understand command "{command}"')
         except Exception as e:
             self.logger.error(f'Received malformed command: {command}')


### PR DESCRIPTION
The time between different values can vary by up to 8ms, so 1ms of drift doesn't prevent hitting the duplicate-value problem. This PR adds a tweak so if we do get a duplicate, we try again once, because pinging the db takes ~30ms which is longer than any reasonable variation.