### PR TITLE
Release listener ports on shutdown

### DIFF
--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -38,6 +38,7 @@ class Monitor(object):
         self.event.set()
         self.shutdown()
         self.listener.join()
+        self.db.release_listener_port(self.name)
         pop = []
         thread_numbers = self.threads.keys()
         for thread_number in thread_numbers:

--- a/Doberman/Database.py
+++ b/Doberman/Database.py
@@ -412,10 +412,9 @@ class Database(object):
         for port in itertools.count(min(existing_ports)):
             if port in existing_ports:
                 continue
-            break
-        self.logger.info(f'Assigning {host}:{port} to {name}')
-        self.update_db('experiment_config', {'name': 'hypervisor'}, {'$set': {f'global_dispatch.{name}': [host, port]}})
-        return host, port
+            self.logger.info(f'Assigning {host}:{port} to {name}')
+            self.update_db('experiment_config', {'name': 'hypervisor'}, {'$set': {f'global_dispatch.{name}': [host, port]}})
+            return host, port
 
     def release_listener_port(self, name):
         """


### PR DESCRIPTION
Rather than have listener ports be assigned in perpetuity, we should return them to the pool when that process shuts down. This ensures we don't store leases for things that will never be used again.