### PR TITLE
Improved thread overwatching

### DIFF
--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -23,8 +23,8 @@ class AlarmMonitor(Doberman.Monitor):
                                                      {'start': {'$lte': now}, 'end': {'$gte': now}},
                                                      onlyone=True)['shifters']
         self.current_shifters.sort()
-        self.register(obj=self.check_for_alarms, period=5, name='alarmcheck')
-        self.register(obj=self.check_shifters, period=60, name='shiftercheck')
+        self.register(obj=self.check_for_alarms, period=5, name='alarmcheck', _no_stop=True)
+        self.register(obj=self.check_shifters, period=60, name='shiftercheck', _no_stop=True)
 
     def get_connection_details(self, which):
         detail_doc = self.db.get_experiment_config('alarm')

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -39,11 +39,8 @@ class Device(object):
 
     def base_setup(self):
         try:
-            self.setup_child()
             self.setup()
             time.sleep(0.2)
-            self.readout_thread = threading.Thread(target=self.readout_scheduler)
-            self.readout_thread.start()
         except Exception as e:
             self.logger.error('Something went wrong during initialization...')
             self.logger.error(type(e))
@@ -67,13 +64,7 @@ class Device(object):
         If a device needs to receive a command after opening but
         before starting "normal" operation, that goes here
         """
-
-    def setup_child(self):
-        """
-        A function for a child class to implement with any setup that needs
-        to be done before handing off to the user's code (such as opening a
-        hardware connection)
-        """
+        pass
 
     def readout_scheduler(self):
         """
@@ -85,22 +76,25 @@ class Device(object):
         """
         self.logger.debug('Readout scheduler starting')
         while not self.event.is_set():
-            command = None
-            with self.cv:
-                self.cv.wait_for(lambda: (len(self.cmd_queue) > 0 or self.event.is_set()))
-                if len(self.cmd_queue) > 0:
-                    command, ret = self.cmd_queue.pop(0)
-            if command is not None:
-                self.logger.debug(f'Executing {command}')
-                t_start = time.time()  # we don't want perf_counter because we care about
-                pkg = self.send_recv(command)
-                t_stop = time.time()  # the clock time when the data came out not cpu time
-                pkg['time'] = 0.5*(t_start + t_stop)
-                if ret is not None:
-                    d, cv = ret
-                    with cv:
-                        d.update(pkg)
-                        cv.notify()
+            try:
+                command = None
+                with self.cv:
+                    self.cv.wait_for(lambda: (len(self.cmd_queue) > 0 or self.event.is_set()))
+                    if len(self.cmd_queue) > 0:
+                        command, ret = self.cmd_queue.pop(0)
+                if command is not None:
+                    self.logger.debug(f'Executing {command}')
+                    t_start = time.time()  # we don't want perf_counter because we care about
+                    pkg = self.send_recv(command)
+                    t_stop = time.time()  # the clock time when the data came out not cpu time
+                    pkg['time'] = 0.5*(t_start + t_stop)
+                    if ret is not None:
+                        d, cv = ret
+                        with cv:
+                            d.update(pkg)
+                            cv.notify()
+            except Exception as e:
+                self.logger.error(f'Scheduler caught a {type(e)} while processing {command}: {e}')
         self.logger.debug('Readout scheduler returning')
 
     def add_to_schedule(self, command, ret=None):
@@ -165,10 +159,8 @@ class Device(object):
 
     def close(self):
         self.event.set()
-        if hasattr(self, 'readout_thread'):
-            with self.cv:
-                self.cv.notify()
-            self.readout_thread.join()
+        with self.cv:
+            self.cv.notify()
         self.shutdown()
 
     def __del__(self):
@@ -205,7 +197,7 @@ class SerialDevice(Device):
     Serial device class. Implements more direct serial connection specifics
     """
 
-    def setup_child(self):
+    def setup(self):
         if not has_serial:
             raise ValueError('This host doesn\'t have the serial library')
         self._device = serial.Serial()
@@ -267,7 +259,7 @@ class LANDevice(Device):
     Class for LAN-connected devices
     """
 
-    def setup_child(self):
+    def setup(self):
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
@@ -312,7 +304,7 @@ class CheapSocketDevice(LANDevice):
     """
     Some hardware treats sockets as disposable and expects a new one for each connection, so we do that here
     """
-    def setup_child(self):
+    def setup(self):
         self.packet_bytes = 1024
         self._device = None
         self._connected = True

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -147,7 +147,7 @@ class Device(object):
         try:
             cmd = self.execute_command(quantity, value)
         except Exception as e:
-            self.logger.info(f'Tried to process command "{command}", got a {type(e)}: {e}')
+            self.logger.info(f'Tried to process command "{cmd}", got a {type(e)}: {e}')
             cmd = None
         if cmd is not None:
             self.add_to_schedule(command=cmd)

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -41,7 +41,7 @@ class Monitor(object):
         self.shutdown()
         self.db.release_listener_port(self.name)
         pop = []
-        for n,t in self.threads.items():
+        for n, t in self.threads.items():
             try:
                 t.event.set()
                 t.join()
@@ -75,7 +75,7 @@ class Monitor(object):
                 func = partial(obj, **kwargs)
             else:
                 func = obj
-            self.restart_info[name] = (func, period) # store for restarting later if necessary
+            self.restart_info[name] = (func, period)  # store for restarting later if necessary
             t = FunctionHandler(func=func, logger=self.logger, period=period, name=name)
         if _no_stop:
             self.no_stop_threads.add(name)
@@ -160,10 +160,12 @@ class FunctionHandler(threading.Thread):
             self.event.wait(loop_top + self.period - time.time())
         self.logger.debug(f'Returning {self.name}')
 
+
 class Listener(threading.Thread):
     """
     This class listens for incoming commands and handles them
     """
+
     def __init__(self, port, logger, event, process_command):
         threading.Thread.__init__(self)
         self.port = port
@@ -191,4 +193,3 @@ class Listener(threading.Thread):
                 except Exception as e:
                     self.logger.info(f'Listener caught a {type(e)} while handling {data} from {addr}: {e}')
         self.logger.debug('Listener shutting down')
-

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -149,8 +149,8 @@ class FunctionHandler(threading.Thread):
         """
         self.logger.debug(f'Starting {self.name}')
         while not self.event.is_set():
+            loop_top = time.time()
             try:
-                loop_top = time.time()
                 self.logger.debug(f'Running {self.name}')
                 ret = self.func()
                 if isinstance(ret, (int, float)) and 0. < ret:

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -21,12 +21,14 @@ class Monitor(object):
         self.logger.debug('Monitor constructing')
         self.event = threading.Event()
         self.threads = {}
+        self.restart_info = {}
+        self.no_stop_threads = set()
         self.sh = Doberman.utils.SignalHandler(self.logger, self.event)
-        self.setup()
-        self.register(obj=self.check_threads, period=30, name='checkthreads')
+        self.register(obj=self.check_threads, period=30, name='checkthreads', _no_stop=True)
         _, port = self.db.assign_listener_address(self.name)
-        self.listener = Listener(port, logger, self.event, lambda cmd: self.process_command(cmd))
-        self.listener.start()
+        l = Listener(port, logger, self.event, lambda cmd: self.process_command(cmd))
+        self.register(name='listener', obj=l, _no_stop=True)
+        self.setup()
 
     def __del__(self):
         pass
@@ -37,21 +39,30 @@ class Monitor(object):
         """
         self.event.set()
         self.shutdown()
-        self.listener.join()
         self.db.release_listener_port(self.name)
         pop = []
-        thread_numbers = self.threads.keys()
-        for thread_number in thread_numbers:
+        for n,t in self.threads.items():
             try:
-                self.threads[thread_number].event.set()
-                self.threads[thread_number].join()
+                t.event.set()
+                t.join()
             except Exception as e:
-                self.logger.debug(f'Can\'t close {thread_number}-thread. {e}')
+                self.logger.debug(f'Can\'t close {n}-thread. {e}')
             else:
-                pop += [thread_number]
+                pop.append(n)
         map(self.threads.pop, pop)
 
-    def register(self, name, obj, period=None, **kwargs):
+    def register(self, name, obj, period=None, _no_stop=False, **kwargs):
+        """
+        Register a new function/thing to be called regularly.
+
+        :param name: the name of the thing
+        :param obj: either a function or a threading.Thread
+        :param period: how often (in seconds) you want this thing done. If obj is a
+            function and returns a number, this will be used as the period. Default None
+        :param _no_stop: bool, should this thread be allowed to stop? Default false
+        :param **kwargs: any kwargs that obj needs to be called
+        :returns: None
+        """
         self.logger.debug('Registering ' + name)
         if isinstance(obj, threading.Thread):
             # obj is a thread
@@ -64,7 +75,10 @@ class Monitor(object):
                 func = partial(obj, **kwargs)
             else:
                 func = obj
+            self.restart_info[name] = (func, period) # store for restarting later if necessary
             t = FunctionHandler(func=func, logger=self.logger, period=period, name=name)
+        if _no_stop:
+            self.no_stop_threads.add(name)
         t.start()
         self.threads[name] = t
 
@@ -85,6 +99,9 @@ class Monitor(object):
         """
         Stops a specific thread. Thread is removed from thread dictionary
         """
+        if name in self.no_stop_threads:
+            self.logger.error(f'Asked to stop thread {name}, but not permitted')
+            return
         if name in self.threads:
             self.threads[name].event.set()
             self.threads[name].join()
@@ -97,13 +114,15 @@ class Monitor(object):
         Checks to make sure all threads are running. Attempts to restart any
         that aren't
         """
-        for n, t in list(self.threads.items()):
+        for n, t in self.threads.items():
             if not t.is_alive():
-                try:
-                    self.logger.info(f'{n}-thread died')
-                    self.stop_thread(n)
-                except Exception as e:
-                    self.logger.error(f'{n}-thread won\'t quit: {e}')
+                self.logger.critical(f'{n}-thread died')
+                if n in self.restart_info:
+                    try:
+                        func, period = self.restart_info[n]
+                        self.register(name=n, obj=func, period=period)
+                    except Exception as e:
+                        self.logger.error(f'{n}-thread won\'t restart: {e}')
 
     def process_command(self, command):
         """
@@ -121,7 +140,7 @@ class FunctionHandler(threading.Thread):
         self.event = event or threading.Event()
         self.func = func
         self.logger = logger
-        self.period = period
+        self.period = period or 10
         self.name = name
 
     def run(self):
@@ -130,11 +149,14 @@ class FunctionHandler(threading.Thread):
         """
         self.logger.debug(f'Starting {self.name}')
         while not self.event.is_set():
-            loop_top = time.time()
-            self.logger.debug(f'Running {self.name}')
-            ret = self.func()
-            if isinstance(ret, (int, float)) and 0. < ret:
-                self.period = ret
+            try:
+                loop_top = time.time()
+                self.logger.debug(f'Running {self.name}')
+                ret = self.func()
+                if isinstance(ret, (int, float)) and 0. < ret:
+                    self.period = ret
+            except Exception as e:
+                self.logger.error(f'{self.name} caught a {type(e)}: {e}')
             self.event.wait(loop_top + self.period - time.time())
         self.logger.debug(f'Returning {self.name}')
 
@@ -157,6 +179,8 @@ class Listener(threading.Thread):
             sock.bind(('', self.port))
             sock.listen()
             while not self.event.is_set():
+                data = None
+                addr = None
                 try:
                     conn, addr = sock.accept()
                     with conn:
@@ -165,6 +189,6 @@ class Listener(threading.Thread):
                 except socket.timeout:
                     pass
                 except Exception as e:
-                    self.logger.info(f'Listener caught a {type(e)}: {e}')
+                    self.logger.info(f'Listener caught a {type(e)} while handling {data} from {addr}: {e}')
         self.logger.debug('Listener shutting down')
 

--- a/Doberman/Monitor.py
+++ b/Doberman/Monitor.py
@@ -55,7 +55,11 @@ def main(mongo_client):
     logger = Doberman.utils.get_logger(name=kwargs['name'], db=db)
     db.logger = logger
     kwargs['logger'] = logger
-    monitor = ctor(**kwargs)
+    try:
+        monitor = ctor(**kwargs)
+    except Exception as e:
+        logger.critical(f'Caught a {type(e)} while constructing {kwargs["name"]}: {e}')
+        return
     monitor.event.wait()
     print('Shutting down')
     monitor.close()

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -104,7 +104,11 @@ class Hypervisor(Doberman.Monitor):
             cmd.insert(1, '-p')
             cmd.insert(2, f'{port}')
         self.logger.debug(f'Running "{" ".join(cmd)}"')
-        cp = subprocess.run(' '.join(cmd), shell=True, capture_output=True)
+        try:
+            cp = subprocess.run(' '.join(cmd), shell=True, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired as e:
+            self.logger.error(f'Command to {address} timed out!')
+            return
         if cp.stdout:
             self.logger.debug(f'Stdout: {cp.stdout.decode()}')
         if cp.stderr:


### PR DESCRIPTION
On rare occasions we've seen threads disappear silently from Monitors. This is obviously bad for a many reasons. This PR adds two extra layers of protection against this: some threads can be designated as do-not-stop threads, where any call to `stop_thread` will fail with a critical message. Second, objects registered as functions (rather than threads) can get restarted if they do happen to fail.

Also, the ownership of a device's readout scheduling thread has been moved up to the DeviceMonitor class so it can get `registered` and be part of the improved thread monitoring.