### PR TITLE
Improved support for disjoint pipelines

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -50,7 +50,7 @@ class AlarmNode(Doberman.Node):
         """
         Let the outside world know that something is going on
         """
-        if not self.is_silent:
+        if not self.is_silent or self.pipeline.silenced_at_level < self.base_level:
             self.logger.debug(msg)
             if self.hash is None:
                 self.hash = Doberman.utils.make_hash(ts or time.time(), self.pipeline.name)
@@ -58,7 +58,7 @@ class AlarmNode(Doberman.Node):
                 self.logger.warning(f'{self.name} beginning alarm with hash {self.hash}')
             self.escalate()
             self._log_alarm(msg, self.pipeline.name, self.hash, self.base_level, self.escalation_level)
-            self.pipeline.silence_for(self.auto_silence_duration)
+            self.pipeline.silence_for(self.auto_silence_duration, self.base_level)
             self.messages_this_level += 1
         else:
             self.logger.error(msg)

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -93,7 +93,7 @@ class Pipeline(object):
                 if kwargs['name'] in graph:
                     continue
                 upstream = kwargs.get('upstream', [])
-                existing_upstream = [self.graph[u] for u in upstream if u in graph]
+                existing_upstream = [graph[u] for u in upstream if u in graph]
                 if len(upstream) == 0 or len(upstream) == len(existing_upstream):
                     self.logger.debug(f'{kwargs["name"]} ready for creation')
                     # all this node's requirements are created
@@ -165,7 +165,7 @@ class Pipeline(object):
                         nodes_to_check.add(d.name)
                 pl[node] = graph.pop(node)
                 nodes_checked.add(node)
-            self.logger.debug(f'Found set: {set(pl.keys()}')
+            self.logger.debug(f'Found subpipeline: {set(pl.keys())}')
             self.subpipelines.append(pl)
 
     def reconfigure(self, doc):
@@ -176,10 +176,8 @@ class Pipeline(object):
                     if node.name not in doc:
                         doc[node.name] = {}
                     doc[node.name].update(alarm_thresholds=rd['alarm_thresholds'], readout_interval=rd['readout_interval'])
-                if isinstance(node, Doberman.SimpleAlarmNode):
-                    if node.name not in doc:
-                        doc[node.name] = {}
-                    doc[node.name].update(length=rd['alarm_recurrence'])
+                    if isinstance(node, Doberman.SimpleAlarmNode):
+                        doc[node.name].update(length=rd['alarm_recurrence'])
                 if node.name in doc:
                     node.load_config(doc[node.name])
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -5,15 +5,16 @@ __all__ = 'Pipeline'.split()
 
 class Pipeline(object):
     """
-    A generic data-processing pipeline graph intended to replace Storm
+    A generic data-processing pipeline digraph intended to replace Storm
     """
     def __init__(self, **kwargs):
-        self.graph = {}
         self.db = kwargs['db']
         self.logger = kwargs['logger']
         self.name = kwargs['name']
         self.cycles = 0
         self.last_error = -1
+        self.subpipelines = []
+        self.silenced_at_level = None  # to support disjoint alarm pipelines
 
     def stop(self):
         try:
@@ -28,23 +29,29 @@ class Pipeline(object):
         doc = self.db.get_pipeline(self.name)
         self.reconfigure(doc['node_config'])
         status = 'silent' if self.cycles <= self.startup_cycles else doc['status']
+        if status != 'silent':
+            # reset
+            self.silenced_at_level = 0
         timing = {}
         self.logger.debug(f'Pipeline {self.name} cycle {self.cycles}')
-        for node in self.graph.values():
-            t_start = time.time()
-            try:
-                node._process_base(status)
-            except Exception as e:
-                self.last_error = self.cycles
-                msg = f'Pipeline {self.name} node {node.name} threw {type(e)}: {e}'
-                if self.cycles <= self.startup_cycles:
-                    # we expect errors during startup as buffers get filled
-                    self.logger.debug(msg)
-                else:
-                    self.logger.warning(msg)
-                break # probably shouldn't finish the cycle if something errored
-            t_end = time.time()
-            timing[node.name] = (t_end-t_start)*1000
+        for pl in self.subpipelines:
+            for node in pl.values():
+                t_start = time.time()
+                try:
+                    node._process_base(status)
+                except Exception as e:
+                    self.last_error = self.cycles
+                    msg = f'Pipeline {self.name} node {node.name} threw {type(e)}: {e}'
+                    if self.cycles <= self.startup_cycles:
+                        # we expect errors during startup as buffers get filled
+                        self.logger.debug(msg)
+                    else:
+                        self.logger.warning(msg)
+                    # probably shouldn't finish the cycle if something errored
+                    # but we should allow other subpipelines to run
+                    break
+                t_end = time.time()
+                timing[node.name] = (t_end-t_start)*1000
         total_timing = ', '.join(f'{k}: {v:.1f}' for k,v in timing.items())
         self.logger.debug(f'Processing time: total {sum(timing.values()):.1f} ms, individual {total_timing}')
         self.cycles += 1
@@ -79,13 +86,14 @@ class Pipeline(object):
         influx_cfg = self.db.get_experiment_config('influx')
         alarm_cfg = self.db.get_experiment_config('alarm')
         self.depends_on = config['depends_on']
-        while len(self.graph) != len(pipeline_config):
-            start_len = len(self.graph)
+        graph = {}
+        while len(graph) != len(pipeline_config):
+            start_len = len(graph)
             for kwargs in pipeline_config:
-                if kwargs['name'] in self.graph:
+                if kwargs['name'] in graph:
                     continue
                 upstream = kwargs.get('upstream', [])
-                existing_upstream = [self.graph[u] for u in upstream if u in self.graph]
+                existing_upstream = [self.graph[u] for u in upstream if u in graph]
                 if len(upstream) == 0 or len(upstream) == len(existing_upstream):
                     self.logger.debug(f'{kwargs["name"]} ready for creation')
                     # all this node's requirements are created
@@ -113,45 +121,73 @@ class Pipeline(object):
                         setup_kwargs[k] = alarm_cfg[k]
                     n.setup(**setup_kwargs)
                     n.load_config(config.get('node_config', {}).get(n.name, {}))
-                    self.graph[n.name] = n
+                    graph[n.name] = n
                     if isinstance(n, Doberman.BufferNode):
                         num_buffer_nodes += 1
                         longest_buffer = max(longest_buffer, n.buffer.length)
 
-            if (nodes_built := len(self.graph) - start_len) == 0:
+            if (nodes_built := len(graph) - start_len) == 0:
                 # we didn't make any nodes this loop, we're probably stuck
-                created = list(self.graph.keys())
+                created = list(graph.keys())
                 all_nodes = set(d['name'] for d in pipeline_config)
                 self.logger.debug(f'Created {created}')
                 self.logger.debug(f'Didn\'t create {list(all_nodes - set(created))}')
                 raise ValueError('Can\'t construct graph! Check config and logs')
             else:
-                self.logger.debug(f'Created {nodes_built} nodes this iter, {len(self.graph)}/{len(pipeline_config)} total')
+                self.logger.debug(f'Created {nodes_built} nodes this iter, {len(graph)}/{len(pipeline_config)} total')
         for kwargs in pipeline_config:
             for u in kwargs.get('upstream', []):
-                self.graph[u].downstream_nodes.append(self.graph[kwargs['name']])
+                graph[u].downstream_nodes.append(graph[kwargs['name']])
 
         self.startup_cycles = num_buffer_nodes + longest_buffer # I think?
         self.logger.debug(f'I estimate we will need {self.startup_cycles} cycles to start')
 
-    def reconfigure(self, doc):
-        for node in self.graph.values():
-            if isinstance(node, Doberman.AlarmNode):
-                rd = self.db.get_sensor_setting(name=node.input_var)
-                if node.name not in doc:
-                    doc[node.name] = {}
-                doc[node.name].update(alarm_thresholds=rd['alarm_thresholds'], readout_interval=rd['readout_interval'])
-            if isinstance(node, Doberman.SimpleAlarmNode):
-                if node.name not in doc:
-                    doc[node.name] = {}
-                doc[node.name].update(length=rd['alarm_recurrence'])
-            if node.name in doc:
-                node.load_config(doc[node.name])
+        self.calculate_jointedness(self, graph)
 
-    def silence_for(self, duration):
+    def calculate_jointedness(self, graph):
+        """
+        Takes in the graph as created above and figures out how many
+        disjoint sections it has. These sections get separated out into subpipelines
+        """
+        nodes_to_check = set([list(graph.keys())[0]])
+        nodes_checked = set()
+        while len(graph):
+            self.logger.debug(f'{len(graph)} nodes to check')
+            pl = {}
+            while len(nodes_to_check) != 0:
+                node = nodes_to_check.pop()
+                self.logger.debug(f'Checking {node}')
+                for u in graph[node].upstream_nodes:
+                    if u.name not in nodes_checked:
+                        nodes_to_check.add(u.name)
+                for d in graph[node].downstream_nodes:
+                    if d.name not in nodes_checked:
+                        nodes_to_check.add(d.name)
+                pl[node] = graph.pop(node)
+                nodes_checked.add(node)
+            self.logger.debug(f'Found set: {set(pl.keys()}')
+            self.subpipelines.append(pl)
+
+    def reconfigure(self, doc):
+        for pl in self.subpipelines:
+            for node in pl.values():
+                if isinstance(node, Doberman.AlarmNode):
+                    rd = self.db.get_sensor_setting(name=node.input_var)
+                    if node.name not in doc:
+                        doc[node.name] = {}
+                    doc[node.name].update(alarm_thresholds=rd['alarm_thresholds'], readout_interval=rd['readout_interval'])
+                if isinstance(node, Doberman.SimpleAlarmNode):
+                    if node.name not in doc:
+                        doc[node.name] = {}
+                    doc[node.name].update(length=rd['alarm_recurrence'])
+                if node.name in doc:
+                    node.load_config(doc[node.name])
+
+    def silence_for(self, duration, level=0):
         """
         Silence this pipeline for a set amount of time
         """
         self.db.set_pipeline_value(self.name, [('status', 'silent')])
         self.db.log_command(f'pipelinectl_active {self.name}', self.name, self.name, duration)
+        self.silenced_at_level = level
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -149,10 +149,10 @@ class Pipeline(object):
         Takes in the graph as created above and figures out how many
         disjoint sections it has. These sections get separated out into subpipelines
         """
-        nodes_to_check = set([list(graph.keys())[0]])
-        nodes_checked = set()
         while len(graph):
             self.logger.debug(f'{len(graph)} nodes to check')
+            nodes_to_check = set([list(graph.keys())[0]])
+            nodes_checked = set()
             pl = {}
             while len(nodes_to_check) != 0:
                 node = nodes_to_check.pop()

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -14,7 +14,7 @@ class Pipeline(object):
         self.cycles = 0
         self.last_error = -1
         self.subpipelines = []
-        self.silenced_at_level = None  # to support disjoint alarm pipelines
+        self.silenced_at_level = 0  # to support disjoint alarm pipelines
 
     def stop(self):
         try:


### PR DESCRIPTION
Separates nodes into disjoint sets. During processing, if one node throws an error, other sub-pipelines can still operate as usual. Some extra handling is added to allow AlarmNodes to bypass the "silence" requirement if they are of a higher-level than the silencing, so if a pipeline is silenced by a level 1 alarm, but another alarm at level 2 shows up, the level 2 alarm gets logged like the pipeline wasn't silenced.