### PR TITLE
Adds default action for Nodes

### DIFF
--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -17,6 +17,9 @@ class ControlNode(Doberman.Node):
             self._log_command(f'set {self.control_value} {value}', self.control_target,
                     self.name)
 
+    def on_error_do_this(self):
+        self.set_output(self.config.get('default_output', 0))
+
 class GeneralValveControl(ControlNode):
     """
     A generalized valve control node that shunts a lot of the logic to something further up in the

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -11,14 +11,15 @@ class ControlNode(Doberman.Node):
         self.control_target = kwargs['control_target']
         self.control_value = kwargs['control_value']
 
-    def set_output(self, value):
+    def set_output(self, value, _force=False):
         self.logger.debug(f'Setting output to {value}')
-        if not self.is_silent:
+        if not self.is_silent and not _force:
             self._log_command(f'set {self.control_value} {value}', self.control_target,
                     self.name)
 
     def on_error_do_this(self):
-        self.set_output(self.config.get('default_output', 0))
+        if (v := self.config.get('default_output')) is not None:
+            self.set_output(v, _force=True)
 
 class GeneralValveControl(ControlNode):
     """

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -80,6 +80,13 @@ class Node(object):
         """
         pass
 
+    def on_error_do_this(self):
+        """
+        If the pipeline errors, do this thing (ie, closing a valve).
+        Only really makes sense for ControlNodes
+        """
+        pass
+
 class SourceNode(Node):
     """
     A node that adds data into a pipeline, probably by querying a db or something

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -42,6 +42,11 @@ class Pipeline(object):
                     self.logger.debug(msg)
                 else:
                     self.logger.warning(msg)
+                for node in self.graph.values():
+                    try:
+                        node.on_error_do_this()
+                    except:
+                        pass
                 break # probably shouldn't finish the cycle if something errored
             t_end = time.time()
             timing[node.name] = (t_end-t_start)*1000

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -18,7 +18,13 @@ class Pipeline(object):
     def stop(self):
         try:
             self.db.set_pipeline_value(self.name, [('status', 'inactive')])
+            for node in self.graph.values():
+                try:
+                    node.on_error_do_this()
+                except Exception:
+                    pass
         except Exception as e:
+            self.logger.debug(f'Caught a {type(e)} while stopping: {e}')
             pass
 
     def process_cycle(self):
@@ -45,7 +51,7 @@ class Pipeline(object):
                 for node in self.graph.values():
                     try:
                         node.on_error_do_this()
-                    except:
+                    except Exception:
                         pass
                 break # probably shouldn't finish the cycle if something errored
             t_end = time.time()

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -162,7 +162,7 @@ class Pipeline(object):
         """
         while len(graph):
             self.logger.debug(f'{len(graph)} nodes to check')
-            nodes_to_check = set([[list(graph.keys())[0]]])
+            nodes_to_check = set([list(graph.keys())[0]])
             nodes_checked = set()
             pl = {}
             while len(nodes_to_check) != 0:

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -19,14 +19,14 @@ class Pipeline(object):
     def stop(self):
         try:
             self.db.set_pipeline_value(self.name, [('status', 'inactive')])
-            for node in self.graph.values():
-                try:
-                    node.on_error_do_this()
-                except Exception:
-                    pass
+            for pl in self.subpipelines:
+                for node in pl.values():
+                    try:
+                        node.on_error_do_this()
+                    except Exception:
+                        pass
         except Exception as e:
             self.logger.debug(f'Caught a {type(e)} while stopping: {e}')
-            pass
 
     def process_cycle(self):
         """
@@ -162,7 +162,7 @@ class Pipeline(object):
         """
         while len(graph):
             self.logger.debug(f'{len(graph)} nodes to check')
-            nodes_to_check = set([list(graph.keys())[0]])
+            nodes_to_check = set([[list(graph.keys())[0]]])
             nodes_checked = set()
             pl = {}
             while len(nodes_to_check) != 0:


### PR DESCRIPTION
If an error happens during a Pipeline cycle, we should have the option for ControlNodes to do some "default" action, eg closing a valve.