### PR TITLE
Allow general pipeline configuation

### DIFF
--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -112,7 +112,9 @@ class Pipeline(object):
                     for k in 'escalation_config silence_duration'.split():
                         setup_kwargs[k] = alarm_cfg[k]
                     n.setup(**setup_kwargs)
-                    n.load_config(config.get('node_config', {}).get(n.name, {}))
+                    node_config = config.get('pipeline_config', {})
+                    node_config.update(config.get('node_config', {}).get(n.name, {}))
+                    n.load_config(node_config)
                     self.graph[n.name] = n
                     if isinstance(n, Doberman.BufferNode):
                         num_buffer_nodes += 1

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -112,7 +112,7 @@ class Pipeline(object):
                     for k in 'escalation_config silence_duration'.split():
                         setup_kwargs[k] = alarm_cfg[k]
                     n.setup(**setup_kwargs)
-                    node_config = config.get('pipeline_config', {})
+                    node_config = config.get('node_config', {}).get('general', {})
                     node_config.update(config.get('node_config', {}).get(n.name, {}))
                     n.load_config(node_config)
                     self.graph[n.name] = n


### PR DESCRIPTION
As well as putting configuration options per node under `node_config.node` you can put them under `pipeline_config` to be shared across the pipeline. Solves #164 