### PR TITLE
Organizational changes

### DIFF
--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -185,7 +185,7 @@ class AlarmMonitor(Doberman.PipelineMonitor):
                 try:
                     self.send_phonecall(recipients, message)
                 except Exception as e:
-                    self.logger.error('Unable to make call: {type(e)}, {e}')
+                    self.logger.error(f'Unable to make call: {type(e)}, {e}')
             else:
                 self.logger.warning(f"Couldn't send alarm message. Protocol {protocol} unknown.")
 
@@ -200,17 +200,17 @@ class AlarmMonitor(Doberman.PipelineMonitor):
             if len(new_shifters) == 0:
                 self.db.update_db('contact', {'name': {'$in': self.current_shifters}}, {'$set': {'on_shift': True}})
                 self.log_alarm(level=1, message='No more allocated shifters.',
-                                  pipeline='AlarmMonitor',
-                                  alarm_hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
-                                  )
+                               pipeline='AlarmMonitor',
+                               _hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
+                               )
                 self.db.update_db('contact', {'name': {'$in': self.current_shifters}}, {'$set': {'on_shift': False}})
                 return
             msg = f'{", ".join(new_shifters)} '
             msg += ('is ' if len(new_shifters) == 1 else 'are ')
             msg += f'now on shift.'
             self.log_alarm(level=1,
-                            message=msg,
-                            pipeline='AlarmMonitor',
-                            alarm_hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
-                              )
+                           message=msg,
+                           pipeline='AlarmMonitor',
+                           _hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
+                           )
             self.current_shifters = new_shifters

--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -13,17 +13,16 @@ dtnow = Doberman.utils.dtnow
 __all__ = 'AlarmMonitor'.split()
 
 
-class AlarmMonitor(Doberman.Monitor):
+class AlarmMonitor(Doberman.PipelineMonitor):
     """
     Class that monitors for alarms and sends messages
     """
 
     def setup(self):
-        now = dtnow()
+        super().setup()
         self.current_shifters = self.db.distinct('contacts', 'name', {'on_shift': True})
         self.current_shifters.sort()
-        self.register(obj=self.check_for_alarms, period=5, name='alarmcheck', _no_stop=True)
-        self.register(obj=self.check_shifters, period=60, name='shiftercheck', _no_stop=True)
+        self.register(obj=self.check_shifters, period=600, name='shiftercheck', _no_stop=True)
 
     def get_connection_details(self, which):
         detail_doc = self.db.get_experiment_config('alarm')
@@ -168,29 +167,7 @@ class AlarmMonitor(Doberman.Monitor):
             return -1
         return 0
 
-    def check_for_alarms(self):
-        doc_filter = {'acknowledged': 0}
-        updates = {'$set': {'acknowledged': dtnow()}}
-        db_col = 'alarm_history'
-        if self.db.count(db_col, doc_filter) == 0:
-            return
-        alarms = {}
-        for doc in self.db.read_from_db(db_col, doc_filter):
-            level = doc['level'] + doc['escalation']
-            logged = datetime.fromtimestamp(int(str(doc['_id'])[:8], 16))
-            if level not in alarms:
-                alarms[level] = {'logged': [], 'msgs': []}
-            alarms[level]['logged'].append(logged)
-            alarms[level]['msgs'].append(doc['msg'])
-        for alarm_level, doc in alarms.items():
-            message = '\n'.join([f'{d.isoformat(sep=" ")}: {m}' for d, m in zip(doc['logged'], doc['msgs'])])
-            self.send_message(int(alarm_level), message)
-        # put the update at the end so if something goes wrong with the message sending then the
-        # alarms don't get acknowledged and lost
-        self.db.update_db(db_col, doc_filter, updates)
-        return
-
-    def send_message(self, level, message):
+    def log_alarm(self, level=None, message=None, pipeline=None, _hash=None):
         """
         Sends 'message' to the contacts specified by 'level'
         """
@@ -222,19 +199,18 @@ class AlarmMonitor(Doberman.Monitor):
         if new_shifters != self.current_shifters:
             if len(new_shifters) == 0:
                 self.db.update_db('contact', {'name': {'$in': self.current_shifters}}, {'$set': {'on_shift': True}})
-                self.db.log_alarm('No more allocated shifters.',
+                self.log_alarm(level=1, message='No more allocated shifters.',
                                   pipeline='AlarmMonitor',
                                   alarm_hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
-                                  base=1,
-                                  escalation=0)
+                                  )
                 self.db.update_db('contact', {'name': {'$in': self.current_shifters}}, {'$set': {'on_shift': False}})
                 return
             msg = f'{", ".join(new_shifters)} '
             msg += ('is ' if len(new_shifters) == 1 else 'are ')
             msg += f'now on shift.'
-            self.db.log_alarm(msg,
-                              pipeline='AlarmMonitor',
-                              alarm_hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
-                              base=1,
-                              escalation=0)
+            self.log_alarm(level=1,
+                            message=msg,
+                            pipeline='AlarmMonitor',
+                            alarm_hash=Doberman.utils.make_hash(time.time(), 'AlarmMonitor'),
+                              )
             self.current_shifters = new_shifters

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -57,11 +57,12 @@ class AlarmNode(Doberman.Node):
                 self.alarm_start = ts or time.time()
                 self.logger.warning(f'{self.name} beginning alarm with hash {self.hash}')
             self.escalate()
-            self._log_alarm(level=self.base_level + self.escalation_level,
+            level = self.base_level + self.escalation_level
+            self._log_alarm(level=level,
                             message=msg,
                             pipeline=self.pipeline.name,
                             _hash=self.hash)
-            self.pipeline.silence_for(self.auto_silence_duration[self.base_level + self.escalation_level], self.base_level)
+            self.pipeline.silence_for(self.auto_silence_duration[level], self.base_level)
             self.messages_this_level += 1
         else:
             self.logger.error(msg)

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -61,7 +61,7 @@ class AlarmNode(Doberman.Node):
                             message=msg,
                             pipeline=self.pipeline.name,
                             _hash=self.hash)
-            self.pipeline.silence_for(self.auto_silence_duration, self.base_level)
+            self.pipeline.silence_for(self.auto_silence_duration[self.base_level + self.escalation_level], self.base_level)
             self.messages_this_level += 1
         else:
             self.logger.error(msg)

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -57,7 +57,10 @@ class AlarmNode(Doberman.Node):
                 self.alarm_start = ts or time.time()
                 self.logger.warning(f'{self.name} beginning alarm with hash {self.hash}')
             self.escalate()
-            self._log_alarm(msg, self.pipeline.name, self.hash, self.base_level, self.escalation_level)
+            self._log_alarm(level=self.base_level + self.escalation_level,
+                            message=msg,
+                            pipeline=self.pipeline.name,
+                            _hash=self.hash)
             self.pipeline.silence_for(self.auto_silence_duration, self.base_level)
             self.messages_this_level += 1
         else:

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -21,96 +21,51 @@ class ControlNode(Doberman.Node):
         if (v := self.config.get('default_output')) is not None:
             self.set_output(v, _force=True)
 
-class GeneralValveControl(ControlNode):
+class DigitalControl(ControlNode):
     """
-    A generalized valve control node that shunts a lot of the logic to something further up in the
-    pipeline.
+    A generalized node to handle digital output. The logic is assumed to be
+    upstream.
     """
     def process(self, package):
         if package['condition_a']:
-            # value is too low and valve is probably closed
             self.logger.info('Condition a met')
             self.set_output(self.config.get('output_a', 1))
         elif package['condition_b']:
-            # value is too high and valve is probably open
             self.logger.info('Condition b met')
             self.set_output(self.config.get('output_b', 0))
 
-class ValveControlNode(ControlNode):
+class AnalogControl(ControlNode):
     """
-    A logic node to control a nitrogen level valve, based on a levelmeter and a control valve,
-    with optional inhibits from a vacuum or a scale
+    A generalized node to handle analog output. The logic is assumed to be
+    upstream
     """
     def process(self, package):
-        liquid_level = package['liquid_level']
-        fill_rate = package['liquid_level_rate']
-        valve_status = package['valve_state']
+        val = package[self.input_var]
+        if (min_output := self.config.get('min_output')) is not None:
+            val = max(val, min_output)
+        if (max_output := self.config.get('max_output')) is not None:
+            val = min(val, max_output)
+        self.set_output(val)
 
-        low_level = self.config['liquid_level_low']
-        high_level = self.config['liquid_level_high']
-        min_fill_rate = self.config['min_fill_rate']
-        max_fill_time = self.config['max_fill_time']
-        max_iso_vac = self.config.get('max_iso_vac', -1)
-        min_scale = self.config.get('min_scale', -1)
-        vac_is_good = max_iso_vac == -1 or package.get('iso_vac_pressure', 0) < max_iso_vac
-        scale_is_good = min_scale == -1 or package.get('scale_weight', 0) < min_scale
+class PipelineControl(ControlNode):
+    """
+    Sometimes you want one pipeline to control another. Currently no idea how
+    to implement this inside the current constraints.
+    """
+    def process(self, package):
+        pass
 
-        some_value = 10000 # FIXME
+    def control_pipeline(self, pipeline, action):
+        if self.is_silent:
+            return
+        if pipeline.startswith('control'):
+            # we can do this directly
+            self.pipeline.monitor.process_command(f'pipelinectl_{action} {pipeline}')
+            return
+        if pipeline.startswith('alarm'):
+            target = 'pl_alarm'
+        elif pipeline.startswith('convert'):
+            target = 'pl_convert'
+        self.pipeline.db.log_command(f'pipelinectl_{action} {pipeline}', to=target,
+                issuer=self.pipeline.name)
 
-        if liquid_level < low_level:
-            if valve_status == 0:
-                # valve is closed, level is too low
-                if vac_is_good and scale_is_good:
-                    # open the valve
-                    self.set_output(1)
-                    self.valve_opened = package['time']
-                    self.logger.info('Scheduling valve opening')
-                else:
-                    self.logger.info('Would love to open the valve but either the scale or vac is out of range')
-            else:
-                # valve is open, check to see for how long
-                if hasattr(self, 'valve_opened'):
-                    if (dt := (package['time']-self.valve_opened)) > some_value:
-                        # filling too slowly! Something fishy
-                        # TODO something reasonable
-                        pass
-                    else:
-                        # probably still waiting for the pipes to chill
-                        pass
-                else:
-                    # we don't have a self.valve_opened, valve was probably opened by something else
-                    # TODO how to handle?
-                    pass
-
-        elif low_level < liquid_level < high_level:
-            if valve_status == 1:
-                if hasattr(self, 'valve_opened'):
-                    if (dt := (package['time']-self.valve_opened)) > max_fill_time:
-                        # filling too long!
-                        # TODO something reasonable
-                        self.logger.critical(f'Valve has been open for {dt/60:.1f} minutes without reaching full, something wrong?')
-                    else:
-                        if fill_rate < min_fill_rate and dt > some_value:
-                            # filling too slowly! Something fishy
-                            # TODO something reasonable
-                            pass
-                        else:
-                            fill_pct = (liquid_level - low_level)/(high_level - low_level)
-                            self.logger.debug(f'Valve has been open for {int(dt//60)}m{int(dt%60)}s, filling at {fill_rate:.1f} ({fill_pct:.1f}%)')
-                else:
-                    # we don't have a self.valve_opened, valve was probably opened by something else
-                    # TODO how to handle?
-                    pass
-            else:
-                # valve is closed, we're in "normal" conditions
-                pass
-
-        else:
-            # liquid level > high
-            if valve_status == 1:
-                # reached FULL
-                self.set_output(0)
-                self.logger.info('Scheduling valve closing')
-            else:
-                # valve is closed
-                pass

--- a/Doberman/Monitor.py
+++ b/Doberman/Monitor.py
@@ -12,9 +12,10 @@ def main(mongo_client):
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--alarm', action='store_true', help='Start the alarm monitor')
-    group.add_argument('--hypervisor', action='store_true', help='Start the hypervisor')
+    group.add_argument('--control', action='store_true', help='Start the Control pipeline monitor')
+    group.add_argument('--convert', action='store_true', help='Start the Convert pipeline monitor')
     group.add_argument('--device', help='Start the specified device monitor')
-    group.add_argument('--pipeline', help='Start a pipeline monitor')
+    group.add_argument('--hypervisor', action='store_true', help='Start the hypervisor')
     group.add_argument('--status', action='store_true', help='Current status snapshot')
     args = parser.parse_args()
 
@@ -28,7 +29,13 @@ def main(mongo_client):
     # TODO add checks for running systems
     if args.alarm:
         ctor = Doberman.AlarmMonitor
-        kwargs['name'] = 'alarm_monitor'
+        kwargs['name'] = 'pl_alarm'
+    elif args.control:
+        ctor = Doberman.PipelineMonitor
+        kwargs['name'] = 'pl_control'
+    elif args.convert:
+        ctor = Doberman.PipelineMonitor
+        kwargs['name'] = 'pl_convert'
     elif args.hypervisor:
         doc = db.get_experiment_config(name='hypervisor')
         if doc['status'] == 'online':
@@ -43,9 +50,6 @@ def main(mongo_client):
         kwargs['name'] = args.device
         if 'Test' in args.device:
             db.experiment_name = 'testing'
-    elif args.pipeline:
-        kwargs['name'] = f'{args.pipeline}'
-        ctor = Doberman.PipelineMonitor
     elif args.status:
         pprint.pprint(db.get_current_status())
         return

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -157,6 +157,7 @@ class InfluxSourceNode(SourceNode):
         except Exception as e:
             raise ValueError(f'Error parsing data: {response.content}')
         timestamp = int(timestamp)
+        self.logger.debug(f'{self.name} got timestamp {timestamp}')
         val = float(val) # 53 bits of precision and we only ever have small integers
         return timestamp, val
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -160,7 +160,7 @@ class Pipeline(object):
         self.startup_cycles = num_buffer_nodes + longest_buffer # I think?
         self.logger.debug(f'I estimate we will need {self.startup_cycles} cycles to start')
 
-        self.calculate_jointedness(self, graph)
+        self.calculate_jointedness(graph)
 
     def calculate_jointedness(self, graph):
         """

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -11,6 +11,7 @@ class Pipeline(object):
         self.db = kwargs['db']
         self.logger = kwargs['logger']
         self.name = kwargs['name']
+        self.monitor = kwargs['monitor']
         self.cycles = 0
         self.last_error = -1
         self.subpipelines = []
@@ -126,7 +127,7 @@ class Pipeline(object):
                     setup_kwargs['influx_cfg'] = influx_cfg
                     setup_kwargs['operation'] = kwargs.get('operation')
                     setup_kwargs['write_to_influx'] = self.db.write_to_influx
-                    setup_kwargs['log_alarm'] = self.db.log_alarm
+                    setup_kwargs['log_alarm'] = self.monitor.log_alarm
                     setup_kwargs['log_command'] = self.db.log_command
                     for k in 'target value'.split():
                         setup_kwargs[f'control_{k}'] = kwargs.get(f'control_{k}')

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -44,6 +44,7 @@ class PipelineMonitor(Doberman.Monitor):
         del self.pipelines[name]
 
     def process_command(self, command):
+        self.logger.debug(f'Processing {command}')
         try:
             if command.startswith('pipelinectl_start'):
                 _, name = command.split(' ')

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -27,9 +27,8 @@ class Hypervisor(Doberman.Monitor):
 
         # start the three Pipeline monitors
         path = self.config['path']
-        self.run_locally(f'cd {path} && ./start_process.sh --alarm')
-        for pl in 'pl_control pl_convert'.split():
-            self.run_locally(f'cd {path} && ./start_process.sh --pipeline {pl}')
+        for thing in 'alarm control convert'.split():
+            self.run_locally(f'cd {path} && ./start_process.sh --{thing}')
 
         # now start the rest of the things
         self.username = self.config.get('username', 'doberman')

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -13,25 +13,39 @@ dtnow = Doberman.utils.dtnow
 
 class Hypervisor(Doberman.Monitor):
     """
-    A tool to monitor and restart processes when necessary
+    A tool to monitor and restart processes when necessary. It is assumed
+    that this is the first thing started, and that nothing is already running.
     """
     def setup(self) -> None:
         self.update_config(status='online')
         self.config = self.db.get_experiment_config('hypervisor')
+
+        # first, cleanup port leases after a potential dirty shutdown
+        hn, p = self.config['global_dispatch']['hypervisor']
+        self.db.update_db('experiment_config', {'name': 'hypervisor'},
+                {'$set': {'global_dispatch': {'hypervisor': [hn, p]}}})
+
+        # start the three Pipeline monitors
+        path = self.config['path']
+        self.run_locally(f'cd {path} && ./start_process.sh --alarm')
+        for pl in 'pl_control pl_convert'.split():
+            self.run_locally(f'cd {path} && ./start_process.sh --pipeline {pl}')
+
+        # now start the rest of the things
         self.username = self.config.get('username', 'doberman')
         self.localhost = self.config['host']
-        self.register(obj=self.hypervise, period=self.config['period'], name='hypervise', _no_stop=True)
-        self.register(obj=self.compress_logs, period=86400, name='log_compactor', _no_stop=True)
-        if (rhb := self.config.get('remote_heartbeat', {}).get('status', '')) == 'send':
-            self.register(obj=self.send_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
-        elif rhb == 'receive':
-            self.register(obj=self.check_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
         self.last_restart = {}
         self.known_devices = self.db.distinct('devices', 'name')
         self.cv = threading.Condition()
         self.dispatch_queue = Doberman.utils.SortedBuffer()
         self.dispatcher = threading.Thread(target=self.dispatch)
         self.dispatcher.start()
+        self.register(obj=self.hypervise, period=self.config['period'], name='hypervise', _no_stop=True)
+        self.register(obj=self.compress_logs, period=86400, name='log_compactor', _no_stop=True)
+        if (rhb := self.config.get('remote_heartbeat', {}).get('status', '')) == 'send':
+            self.register(obj=self.send_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
+        elif rhb == 'receive':
+            self.register(obj=self.check_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
 
     def shutdown(self) -> None:
         with self.cv:
@@ -60,6 +74,7 @@ class Hypervisor(Doberman.Monitor):
         # cache these here because they might change during iteration
         managed = self.config['processes']['managed']
         active = self.config['processes']['active']
+        self.known_devices = self.db.distinct('devices', 'name')
         for device in managed:
             if device not in active:
                 # device isn't running and it's supposed to be
@@ -73,6 +88,8 @@ class Hypervisor(Doberman.Monitor):
                 elif self.start_device(device):
                     # nonzero return code, probably something didn't work
                     self.logger.error(f'Problem starting {device}, check the debug logs')
+                else:
+                    self.logger.debug(f'{device} restarted')
             else:
                 # claims to be active and has heartbeated recently
                 self.logger.debug(f'{device} last heartbeat {int(dt)} seconds ago')
@@ -137,14 +154,6 @@ class Hypervisor(Doberman.Monitor):
             return self.run_locally(command)
         return self.run_over_ssh(f'{self.username}@{host}', command)
 
-    def start_pipeline(self, pipeline: str) -> int:
-        if pipeline.startswith('alarm_'):
-            # this is an alarm pipeline
-            self.db.log_command(f'start {pipeline}', 'pl_alarm', 'hypervisor')
-            return 0
-        path = self.config['path']
-        return self.run_locally(f'cd {path} && ./start_process.sh -p {pipeline}')
-
     def compress_logs(self) -> None:
         then = dtnow()-datetime.timedelta(days=7)
         self.logger.info(f'Compressing logs from {then.year}-{then.month:02d}-{then.day:02d}')
@@ -161,6 +170,7 @@ class Hypervisor(Doberman.Monitor):
         self.logger.debug('Dispatcher starting up')
         while not self.event.is_set():
             doc = None
+            hn = None
             try:
                 with self.cv:
                     self.cv.wait_for(predicate, timeout=dt)
@@ -174,10 +184,6 @@ class Hypervisor(Doberman.Monitor):
                     if doc['to'] == 'hypervisor':
                         self.process_command(doc['command'])
                         continue
-                    if doc['to'] in self.db.distinct('pipelines', 'name') and \
-                            self.db.get_pipeline(doc['to'])['status'] == 'inactive':
-                        self.logger.warning(f'Can\'t send "{doc["command"]}" to {doc["to"]} because it isn\'t online')
-                        continue
                     if doc['to'] in self.known_devices and doc['to'] not in self.config['processes']['active']:
                         self.logger.warning(f'Can\'t send "{doc["command"]}" to {doc["to"]} because it isn\'t online')
                         continue
@@ -186,7 +192,7 @@ class Hypervisor(Doberman.Monitor):
                     with socket.create_connection((hn, p), timeout=0.1) as sock:
                         sock.sendall(doc['command'].encode())
             except Exception as e:
-                self.logger.warning(f'Dispatcher caught a {type(e)}: {e}')
+                self.logger.warning(f'Dispatcher caught a {type(e)} while messaging {hn}: {e}')
         self.logger.debug('Dispatcher shutting down')
 
     def process_command(self, command) -> None:
@@ -203,8 +209,6 @@ class Hypervisor(Doberman.Monitor):
             self.logger.info(f'Hypervisor starting {target}')
             if target in self.known_devices:
                 self.start_device(target)
-            elif self.db.count('pipelines', {'name': target}) == 1:
-                self.start_pipeline(target)
             else:
                 self.logger.error(f'Don\'t know what "{target}" is, can\'t start it')
 

--- a/scripts/start_process.sh
+++ b/scripts/start_process.sh
@@ -1,27 +1,30 @@
 #!/bin/bash
 
-USAGE="Usage: $0 [--alarm] [-d <device>] [-p <pipeline>] [--hypervisor]"
+USAGE="Usage: $0 [--alarm] [--control] [--convert] [--device <device>] [--hypervisor]"
 folder="/global/software/doberman/Doberman"
 
 x=0
 
 while [[ $1 =~ ^- && ! $1 == '--' ]]; do case $1 in
-  -a | --alarm )
+  --alarm )
     target="alarm"
     screen_name="alarm_monitor"
+    x=$((x+1))
+    ;;
+  --control )
+    target="control"
+    screen_name="control_pipeline"
+    x=$((x+1))
+    ;;
+  --convert )
+    target="convert"
+    screen_name="convert_pipeline"
     x=$((x+1))
     ;;
   -d | --device )
     shift
     name=$1
     target="device"
-    screen_name=$1
-    x=$((x+1))
-    ;;
-  -p | --pipeline )
-    shift
-    name=$1
-    target="pipeline"
     screen_name=$1
     x=$((x+1))
     ;;


### PR DESCRIPTION
A number of organizational changes meant to simplify operation. Including:
- The unification of the alarm monitor and the alarm pipeline monitor
- Pipelines must come in one of three flavors: alarm, control, and convert. A dedicated monitor will handle all pipelines of a given flavor, gone are control pipelines running separately
- The hypervisor will start all three Pipeline monitors when it begins; the assumption is that the hypervisor is the first thing to start, and its job is to bring the rest of the system up.
- The `GeneralValveControl` node has been renamed to `GeneralDigitalControl` to handle two-state outputs, and a corresponding `GeneralAnalogControl` will handle floating-point outputs.
- Scaffolding for a control node to affect pipelines. Not yet functional.