### PR TITLE
Tweaks and cleanup

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -88,10 +88,10 @@ class DeviceRespondingBase(AlarmNode):
             self.reset_alarm()
         return None
 
-class DeviceRespondingAlarmInflux(DeviceRespondingBase, Doberman.InfluxSourceNode):
+class DeviceRespondingInfluxNode(DeviceRespondingBase, Doberman.InfluxSourceNode):
     pass
 
-class DeviceRespondingAlarmSync(DeviceRespondingBase, Doberman.SensorSourceNode):
+class DeviceRespondingSyncNode(DeviceRespondingBase, Doberman.SensorSourceNode):
     pass
 
 class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -21,20 +21,27 @@ class ControlNode(Doberman.Node):
         if (v := self.config.get('default_output')) is not None:
             self.set_output(v, _force=True)
 
-class DigitalControl(ControlNode):
+class DigitalControlNode(ControlNode):
     """
     A generalized node to handle digital output. The logic is assumed to be
     upstream.
     """
-    def process(self, package):
-        if package['condition_a']:
-            self.logger.info('Condition a met')
-            self.set_output(self.config.get('output_a', 1))
-        elif package['condition_b']:
-            self.logger.info('Condition b met')
-            self.set_output(self.config.get('output_b', 0))
+    def setup(self, **kwargs):
+        super().setup(**kwargs)
+        self.one_input = kwargs.get('one_input', False)
 
-class AnalogControl(ControlNode):
+    def process(self, package):
+        if self.one_input:
+            self.logger.set_output(self.input_var)
+        else:
+            if package['condition_a']:
+                self.logger.info('Condition a met')
+                self.set_output(self.config.get('output_a', 1))
+            elif package['condition_b']:
+                self.logger.info('Condition b met')
+                self.set_output(self.config.get('output_b', 0))
+
+class AnalogControlNode(ControlNode):
     """
     A generalized node to handle analog output. The logic is assumed to be
     upstream
@@ -47,19 +54,25 @@ class AnalogControl(ControlNode):
             val = min(val, max_output)
         self.set_output(val)
 
-class PipelineControl(ControlNode):
+class PipelineControlNode(ControlNode):
     """
-    Sometimes you want one pipeline to control another. Currently no idea how
-    to implement this inside the current constraints.
+    Sometimes you want one pipeline to control another.
     """
     def process(self, package):
+        for char in range(ord('c'), ord('z')+1):
+            if package.get(f'condition_{char}', False):
+                # do something
+                action, target = self.config.get(f'action_{char}', (None, None))
+                if action and target:
+                    self.control_pipeline(action, target)
+
         if package.get('condition_test', False):
             # this one is mainly for testing
             self.pipeline.db.log_command(f'pipelinectl_stop test_pipeline',
                     to=self.pipeline.monitor.name, issuer='test_pipeline',
                     bypass_hypervisor=True)
 
-    def control_pipeline(self, pipeline, action):
+    def control_pipeline(self, action, pipeline):
         if self.is_silent:
             return
         if pipeline.startswith('control'):

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -32,7 +32,7 @@ class DigitalControlNode(ControlNode):
 
     def process(self, package):
         if self.one_input:
-            self.logger.set_output(self.input_var)
+            self.set_output(package[self.input_var])
         else:
             if package['condition_a']:
                 self.logger.info('Condition a met')

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -75,7 +75,7 @@ class Node(object):
         Load whatever runtime values are necessary
         """
         for k,v in doc.items():
-            if k == 'length' and isinstance(self, BufferNode):
+            if k == 'length' and isinstance(self, BufferNode) and not isinstance(self, MergeNode):
                 self.buffer.set_length(int(v))
             else:
                 self.config[k] = v
@@ -250,7 +250,7 @@ class BufferNode(Node):
         # deep copy
         return list(map(dict, self.buffer))
 
-class MedianFilter(BufferNode):
+class MedianFilterNode(BufferNode):
     """
     Filters a value by taking the median of its buffer. If the length is even,
     the two values adjacent to the middle are averaged.


### PR DESCRIPTION
Mainly a bit of cleanup:
- The names of all nodes now ends in 'Node'. Previously this was not the case, which made some things ambiguous.
- DigitalControlNodes can now be set to run on a single input, rather than having `condition_a` and `condition_b`. This input will be written directly to the designated target.
- PipelineControlNode now actually implemented
- Can no longer even accidentally send the `length` config option to a MergeNode.