### PR TITLE
New internal communication subsystem

### DIFF
--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -2,7 +2,7 @@ import Doberman
 import threading
 from functools import partial
 import time
-import socket
+import zmq
 
 __all__ = 'Monitor'.split()
 
@@ -28,13 +28,6 @@ class Monitor(object):
         self.restart_info = {}
         self.no_stop_threads = set()
         self.sh = Doberman.utils.SignalHandler(self.logger, self.event)
-        if self.name != 'hypervisor':
-            self.db.assign_listener_address(self.name)
-        _, port = self.db.find_listener_address(self.name)
-        # is the lambda necessary? Maybe? We sometimes crashed without it for
-        # reasons I don't understand
-        l = Listener(port, logger, self.event, lambda cmd: self.process_command(cmd))
-        self.register(name='listener', obj=l, _no_stop=True)
         self.db.notify_hypervisor(active=self.name)
         self.logger.debug('Child setup starting')
         self.setup()
@@ -144,6 +137,43 @@ class Monitor(object):
                         except Exception as e:
                             self.logger.error(f'{n}-thread won\'t restart: {e}')
 
+    def listen(self):
+        """
+        Listens for incoming commands
+        """
+        host, ports = self.db.get_comms_info('command')
+        ctx = zmq.Context.instance()
+        incoming = ctx.socket(zmq.SUB)
+        outgoing = ctx.socket(zmq.REQ)
+
+        incoming.setsockopt_string(zmq.SUBSCRIBE, 'ping')
+        incoming.setsockopt_string(zmq.SUBSCRIBE, self.name)
+
+        incoming.connect(f'tcp://{host}:{ports["recv"]}')
+        outgoing.connect(f'tcp://{host}:{ports["send"]}')
+
+        poller = zmq.Poller()
+        poller.register(incoming, zmq.POLLIN)
+
+        while not self.event.is_set():
+            socks = dict(poller.poll(timeout=1000))
+
+            if socks.get(incoming) == zmq.POLLIN:
+                msg = incoming.recv_string()
+                if msg.startswith('ping'):
+                    outgoing.send_string(f'pong {self.name}')
+                    _ = outgoing.recv_string()
+                else:
+                    try:
+                        # name, hash, command
+                        _, cmd_hash, command = msg.split(' ', maxsplit=2)
+                        self.process_command(command)
+                        outgoing.send_string(f'ack {self.name} {cmd_hash}')
+                        _ = outgoing.recv_string()
+                    except Exception as e:
+                        self.logger.warning(f'Caught a {type(e)} while processing command: {e}')
+                        self.logger.debug(msg)
+
     def process_command(self, command):
         """
         A function for base classes to implement to handle any commands
@@ -180,38 +210,3 @@ class FunctionHandler(threading.Thread):
             self.event.wait(loop_top + self.period - time.time())
         self.logger.debug(f'Returning {self.name}')
 
-
-class Listener(threading.Thread):
-    """
-    This class listens for incoming commands and handles them
-    """
-
-    def __init__(self, port, logger, event, process_command):
-        threading.Thread.__init__(self)
-        self.port = port
-        self.logger = logger
-        self.event = event
-        self.process_command = process_command
-        self.packet_size = 2048
-
-    def run(self):
-        self.logger.debug('Listener starting up')
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.settimeout(1)
-            sock.bind(('', self.port))
-            sock.listen()
-            while not self.event.is_set():
-                data = None
-                addr = None
-                try:
-                    conn, addr = sock.accept()
-                    with conn:
-                        if (data := conn.recv(self.packet_size)) == b'ping':
-                            conn.sendall(b'pong')
-                        else:
-                            self.process_command(data.strip().decode())
-                except socket.timeout:
-                    pass
-                except Exception as e:
-                    self.logger.info(f'Listener caught a {type(e)} while handling {data} from {addr}: {e}')
-        self.logger.debug('Listener shutting down')

--- a/Doberman/Database.py
+++ b/Doberman/Database.py
@@ -330,20 +330,6 @@ class Database(object):
                 onlyone=True)
         return doc[field] if field is not None and field in doc else doc
 
-    def get_runmode_setting(self, runmode=None, field=None):
-        """
-        Reads default Doberman settings from database.
-
-        :param runmode: the runmode to get settings for
-        :param field: the name of the setting
-        :returns: the setting dictionary if name=None, otherwise the specific field
-        """
-        doc = self.read_from_db('runmodes',
-                                {'mode': runmode}, onlyone=True)
-        if field is not None:
-            return doc[field]
-        return doc
-
     def notify_hypervisor(self, active=None, inactive=None, unmanage=None):
         """
         A way for devices to tell the hypervisor when they start and stop and stuff
@@ -362,80 +348,6 @@ class Database(object):
             self.update_db('experiment_config', {'name': 'hypervisor'},
                            updates)
         return
-
-    def assign_listener_address(self, name):
-        """
-        Assign a hostname and port for communication
-        :param name: who will get this assignment
-        :returns: None
-        """
-        if name in self.distinct('devices', 'name'):
-            # this is a device
-            host = self.get_device_setting(name, field='host')
-        else:
-            # probably a pipeline, assume it runs on the master host
-            host = self.find_listener_address('hypervisor')[0]
-
-        # gain an exclusive lock on the collection
-        while self.update_db('dispatch', {'name': '_lock', 'host': '', 'port': -1}, {'$set': {'port': 1}}) == 0:
-            time.sleep(random.random())
-        s = ', '.join(map(lambda d: f'{d["name"]}:{d["port"]}', self.read_from_db('dispatch', {'host': host})))
-        self.logger.debug(f'Existing leases on {host}: {s}')
-        try:
-            self.delete_documents('dispatch', {'host': host, 'name': name})
-            for doc in self.aggregate('dispatch', [
-                {'$match': {'host': host}},
-                {'$group': {
-                    '_id': '$host',
-                    'min_port': {'$min': '$port'},
-                    'max_port': {'$max': '$port'},
-                    'num_ports': {'$sum': 1},
-                    'ports': {'$push': '$port'}}},
-                {'$project': {
-                    'name': name,
-                    'host': '$_id',
-                    '_id': 0,
-                    'port': {'$cond': [
-                                {'$eq': [ # are the ports densely-packed?
-                                    {'$subtract': ['$max_port', '$min_port']},
-                                    {'$subtract': ['$num_ports', 1]}
-                                ]},
-                                {'$add': ['$max_port', 1]}, # if so, max + 1
-                                {'$first': {'$filter': { # if not, find an open port
-                                    'input': {'$range': ['$min_port', '$max_port']},
-                                    'as': 'p',
-                                    'cond': {'$not': {'$in': ['$$p', '$ports']}}
-                                    }}}
-                                ]}
-                    }}]):
-                self.logger.debug(f'Assigning {host}:{doc["port"]}')
-                self.insert_into_db('dispatch', doc)
-        except Exception as e:
-            self.logger.error(f'Caught a {type(e)} during port assignment: {e}')
-        self.update_db('dispatch', {'name': '_lock', 'host': ''}, {'$set': {'port': -1}})
-
-    def find_listener_address(self, name):
-        """
-        Get a hostname and port to communicate over. If none exist, raise an error
-
-        :param name: the name of someone
-        :returns: (string, int) tuple of the hostname and port
-        """
-        if name in self.address_cache:
-            return self.address_cache[name]
-        if (doc := self.read_from_db('dispatch', {'name': name}, onlyone=True)) is None:
-            raise ValueError(f'No assigned listener info for {name}')
-        host, port = doc['host'], doc['port']
-        if name in ['pl_alarm', 'pl_control', 'pl_convert', 'hypervisor']:
-            self.address_cache[name] = (host, int(port))
-        return host, int(port)
-
-    def release_listener_port(self, name):
-        """
-        Return the port used by <name> to the pool
-        """
-        if name != 'hypervisor':
-            self.delete_documents('dispatch', {'name': name})
 
     def get_host_setting(self, host=None, field=None):
         """

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -1,24 +1,37 @@
 import Doberman
 import time
 import threading
+import json
+import zmq
+import collections
 
 __all__ = 'Pipeline SyncPipeline'.split()
 
-class Pipeline(object):
+class Pipeline(threading.Thread):
     """
     A generic data-processing pipeline digraph for simple or complex
     automatable tasks
     """
     def __init__(self, **kwargs):
+        threading.Thread.__ini__(self)
         self.db = kwargs['db']
         self.logger = kwargs['logger']
         self.name = kwargs['name']
         self.monitor = kwargs['monitor']
         self.cycles = 0
         self.last_error = -1
+        self.event = threading.Event()
         self.subpipelines = []
         self.silenced_at_level = 0  # to support disjoint alarm pipelines
         self.required_inputs = set() # this needs to be in this class even though it's only used in Sync
+        self.ctx = kwargs.get('context') or zmq.Context.instance()
+        self.command_socket = self.ctx.socket(zmq.REQ)
+        host, ports = self.db.get_comms_info('command')
+        self.command_socket.connect(f'tcp://{host}:{ports["send"]}')
+        host, ports = self.db.get_comms_info('data')
+        self.data_socket = self.ctx.socket(zmq.PUB)
+        self.data_socket.connect(f'tcp://{host}:{ports["send"]}')
+        self.depends_on = []
 
     @staticmethod
     def create(config, **kwargs):
@@ -31,6 +44,7 @@ class Pipeline(object):
         return Pipeline(**kwargs)
 
     def stop(self):
+        self.event.set()
         try:
             self.db.set_pipeline_value(self.name, [('status', 'inactive')])
             for pl in self.subpipelines:
@@ -41,6 +55,11 @@ class Pipeline(object):
                         pass
         except Exception as e:
             self.logger.debug(f'Caught a {type(e)} while stopping: {e}')
+
+    def run(self):
+        while not self.event.is_set():
+            interval = self.process_cycle()
+            self.event.wait(interval)
 
     def process_cycle(self):
         """
@@ -66,7 +85,7 @@ class Pipeline(object):
                     self.last_error = self.cycles
                     msg = f'Pipeline {self.name} node {node.name} threw {type(e)}: {e}'
                     if isinstance(node, Doberman.SourceNode):
-                        drift = 0.1 # extra few ms to help with misalignment
+                        drift = 0.1  # extra few ms to help with misalignment
                     if self.cycles <= self.startup_cycles:
                         # we expect errors during startup as buffers get filled
                         self.logger.debug(msg)
@@ -82,15 +101,13 @@ class Pipeline(object):
                     break
                 t_end = time.time()
                 timing[node.name] = (t_end-t_start)*1000
-        total_timing = ', '.join(f'{k}: {v:.1f}' for k,v in timing.items())
-        #self.logger.debug(f'Processing time: total {sum(timing.values()):.1f} ms, individual {total_timing}')
         self.cycles += 1
         self.db.set_pipeline_value(self.name,
                 [('heartbeat', Doberman.utils.dtnow()),
                     ('cycles', self.cycles),
                     ('error', self.last_error),
                     ('rate', sum(timing.values()))])
-        drift = max(drift, 0.001) # min 1ms of drift
+        drift = max(drift, 0.001)  # min 1ms of drift
         return max(d['readout_interval'] for d in sensor_docs.values()) + drift
 
     def build(self, config):
@@ -184,7 +201,8 @@ class Pipeline(object):
         self.calculate_jointedness(graph)
 
         # we do the reconfigure step here so we can estimate startup cycles
-        self.reconfigure(config['node_config'], {n: self.db.get_sensor_setting(n) for n in self.depends_on})
+        self.reconfigure(config['node_config'],
+                         {n: self.db.get_sensor_setting(n) for n in self.depends_on})
         for pl in self.subpipelines:
             for node in pl:
                 if isinstance(node, Doberman.BufferNode) and not isinstance(node, Doberman.MergeNode):
@@ -250,34 +268,66 @@ class Pipeline(object):
         """
         Silence this pipeline for a set amount of time
         """
+        doc = {
+                'to': self.monitor.name,
+                'from': self.name,
+                'time': time.time()+duration,
+                'command': f'pipelinectl_active {self.name}'
+                }
         self.db.set_pipeline_value(self.name, [('status', 'silent'), ('silent_until', time.time()+duration)])
-        self.db.log_command(f'pipelinectl_active {self.name}', to=self.monitor.name,
-                issuer=self.name, delay=duration)
+        self.command_socket.send_string(json.dumps(doc))
+        _ = self.command_socket.recv_string()
         self.silenced_at_level = level
 
-class SyncPipeline(threading.Thread, Pipeline):
+    def send_command(self, command, to):
+        """
+        Send a command to the HV
+        """
+        self.command_socket.send_string(json.dumps({
+            'to': to, 'time': time.time(),
+            'from': self.name, 'command': command}))
+        _ = self.command_socket.recv_string()
+
+
+class SyncPipeline(Pipeline):
     """
-    A subclass to handle synchronous operation where input comes directly from
-    the sensors rather than via the database
+    A subclass to handle synchronous operation where input comes from
+    the data communication bus rather than via the database. self.run
+    sits around waiting for data to come in, and only runs once a set
+    minimum number of nodes have received new values.
     """
-    def __init__(self, **kwargs):
-        threading.Thread.__init__(self)
-        Pipeline.__init__(self, **kwargs)
-        self.cv = threading.Condition()
-        self.event = threading.Event()
-        self.has_new = set()
+    def build(self, config):
+        super().build(config)
+        self.listens_for = collections.defaultdict(list)
+        for pl in self.subpipelines:
+            for node in pl:
+                if isinstance(node, Doberman.SensorSourceNode):
+                    self.listens_for[node.input_var].append(node)
 
     def run(self):
-        predicate = lambda: (len(self.has_new) > 0 and self.has_new >= self.required_inputs) or self.event.is_set()
+        socket = self.ctx.socket(zmq.SUB)
+        host, ports = self.db.get_comms_info('data')
+        socket.connect(f'tcp://{host}:{ports["receive"]}')
+        for name in self.depends_on:
+            socket.setsockopt_string(zmq.SUBSCRIBE, name)
+        poller = zmq.Poller()
+        poller.register(socket, zmq.POLLIN)
+        has_new = set()
         while not self.event.is_set():
-            with self.cv:
-                self.cv.wait_for(predicate)
-            self.process_cycle()
-            self.has_new.clear()
-
-    def stop(self):
-        self.event.set()
-        with self.cv:
-            self.cv.notify()
-        return super().stop()
+            socks = dict(poller.poll(timeout=1000))
+            if socks.get(socket) == zmq.POLLIN:
+                try:
+                    msg = socket.recv_string()
+                    n, t, v = msg.split(' ')
+                    t = float(t)
+                    v = float(v) if '.' in v else int(v)
+                    has_new.add(n)
+                    for node in self.listens_for(n):
+                        node.receive_from_upstream({n: v, 'time': t})
+                except Exception as e:
+                    self.logger.debug(f'{type(e)}: {msg}')
+                else:
+                    if has_new >= self.required_inputs:
+                        self.process_cycle()
+                        has_new.clear()
 

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -5,12 +5,14 @@ import time
 import os.path
 import os
 import threading
-import socket
 import json
 import datetime
+import zmq
+from heapq import heappush, heappop
 
 
 dtnow = Doberman.utils.dtnow
+
 
 class Hypervisor(Doberman.Monitor):
     """
@@ -31,29 +33,19 @@ class Hypervisor(Doberman.Monitor):
                 for activity in activities:
                     self.run_over_ssh(f'{self.username}@{host}', activity)
 
-        # cleanup port leases after a potential dirty shutdown
-        hn, p = self.db.find_listener_address('hypervisor')
-        self.db.delete_documents('dispatch', {'name': {'$ne': 'hypervisor'}})
-        self.db.insert_into_db('dispatch', {'host': '', 'name': '_lock', 'port': -1})
-        for doc in self.db.aggregate('hosts', [
-            {'$match': {'name': {'$ne': hn}}},
-            # the toInt is to work around Mongo logic
-            {'$project': {'host': '$name', 'name': '_dummy', 'port': {'$toInt': str(p)}, '_id': 0}},
-            {'$merge': 'dispatch'}]):
-            pass
-
+        self.last_restart = {}
+        self.last_pong = {}
         # start the three Pipeline monitors
         path = self.config['path']
         for thing in 'alarm control convert'.split():
             self.run_locally(f'cd {path} && ./start_process.sh --{thing}')
+            self.last_restart[f'pl_{thing}'] = dtnow()
 
         # now start the rest of the things
-        self.last_restart = {}
         self.known_devices = self.db.distinct('devices', 'name')
         self.cv = threading.Condition()
-        self.dispatch_queue = Doberman.utils.SortedBuffer()
-        self.dispatcher = threading.Thread(target=self.dispatch)
-        self.dispatcher.start() # TODO get this registered somehow
+        self.dispatcher = threading.Thread(target=self.dispatcher)
+        self.dispatcher.start()  # TODO get this registered somehow
         self.register(obj=self.compress_logs, period=86400, name='log_compactor', _no_stop=True)
         if (rhb := self.config.get('remote_heartbeat', {}).get('status', '')) == 'send':
             self.register(obj=self.send_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
@@ -64,24 +56,36 @@ class Hypervisor(Doberman.Monitor):
 
         # start the fixed-frequency sync signals
         self.db.delete_documents('sensors', {'name': {'$regex': '^X_SYNC'}})
-        for i in self.config.get('sync_periods', [5,10,15,30,60]):
+        periods = self.config.get('sync_periods', [5, 10, 15, 30, 60])
+        for i in periods:
             if self.db.get_sensor_setting(name=f'X_SYNC_{i}') is None:
                 self.db.insert_into_db('sensors', {'name': f'X_SYNC_{i}', 'description': 'Sync signal', 'readout_interval': i, 'status': 'offline', 'topic': 'other',
                     'subsystem': 'sync', 'pipelines': [], 'device': 'hypervisor', 'units': '', 'readout_command': ''})
-            self.register(obj=self.sync_signal, period=i, name=f'sync_{i}', _period=i)
+        self.sync = threading.Thread(target=self.sync_signals, args=(periods,))
+        self.sync.start()
 
         time.sleep(1)
         self.register(obj=self.hypervise, period=self.config['period'], name='hypervise', _no_stop=True)
 
-
     def shutdown(self) -> None:
-        with self.cv:
-            self.cv.notify()
+        self.event.set()
         self.update_config(status='offline')
         self.dispatcher.join()
+        self.sync.join()
 
-    def sync_signal(self, _period: int) -> None:
-        self.db.send_value_to_pipelines(f'X_SYNC_{_period}', 0, time.time())
+    def sync_signals(self, periods: list) -> None:
+        ctx = zmq.Context.instance()
+        socket = ctx.socket(zmq.PUB)
+        host, ports = self.db.get_comms_info('data')
+        socket.connect(f'tcp://{host}:{ports["send"]}')
+        now = time.time()
+        q = [(now+p, p) for p in sorted(periods)]
+        while not self.event.is_set():
+            self.event.wait(q[0][0]-time.time())
+            _, p = heappop(q)
+            now = time.time()
+            socket.send_string(f'X_SYNC_{p} {now:.3f} 0')
+            heappush((now+p, p))
 
     def update_config(self, unmanage=None, manage=None, active=None, heartbeat=None, status=None) -> None:
         updates = {}
@@ -106,7 +110,8 @@ class Hypervisor(Doberman.Monitor):
         self.known_devices = self.db.distinct('devices', 'name')
         path = self.config['path']
         for pl in 'alarm control convert'.split():
-            if self.ping(f'pl_{pl}'):
+            if time.time()-self.last_pong.get(f'pl_{pl}', 100) > 30 and \
+                    (dtnow()-self.last_restart[f'pl_{pl}']).total_seconds() > 60:
                 self.run_locally(f'cd {path} && ./start_process.sh --{pl}')
 
         for device in managed:
@@ -122,7 +127,8 @@ class Hypervisor(Doberman.Monitor):
                     self.logger.error(f'Problem starting {device}, check the debug logs')
                 else:
                     self.logger.debug(f'{device} restarted')
-            elif self.ping(device):
+            elif self.last_pong.get(device, 100) > 30 and \
+                    (now-self.last_restart[device]).total_seconds() > 60:
                 self.logger.error(f'Failed to ping {device}, restarting it')
                 self.start_device(device)
             else:
@@ -130,21 +136,6 @@ class Hypervisor(Doberman.Monitor):
                 self.logger.debug(f'{device} last heartbeat {int(dt)} seconds ago')
         self.update_config(heartbeat=dtnow())
         return self.config['period']
-
-    def ping(self, thing: str) -> bool:
-        """
-        Ping a listener. Returns True if it isn't listening and should be restarted
-        """
-        try:
-            hn, p = self.db.find_listener_address(thing)
-            with socket.create_connection((hn, p), timeout=0.1) as sock:
-                sock.sendall(b'ping')
-                if sock.recv(1024) != b'pong':
-                    return True
-        except Exception as e:
-            self.logger.debug(f'Caught a {type(e)} while pinging {thing}: {e}')
-            return True
-        return False
 
     def send_remote_heartbeat(self) -> None:
         # touch a file on a remote server just so someone else knows we're still alive
@@ -173,7 +164,7 @@ class Hypervisor(Doberman.Monitor):
         self.logger.debug(f'Running "{" ".join(cmd)}"')
         try:
             cp = subprocess.run(' '.join(cmd), shell=True, capture_output=True, timeout=30)
-        except subprocess.TimeoutExpired as e:
+        except subprocess.TimeoutExpired:
             self.logger.error(f'Command to {address} timed out!')
             return
         if cp.stdout:
@@ -215,50 +206,107 @@ class Hypervisor(Doberman.Monitor):
         p = self.logger.handlers[0].logdir(dtnow()-datetime.timedelta(days=7))
         self.run_locally(f'cd {p} && gzip --best *.log')
 
-    def dispatch(self) -> None:
-        # if there's nothing to do, wait this long
-        dt_large = 1000
-        # process commands if we're within this much of the desired time
-        min_dt = 0.001
-        dt = dt_large
-        predicate = lambda: (len(self.dispatch_queue) > 0 or self.event.is_set())
-        self.logger.debug('Dispatcher starting up')
+    def data_broker(self) -> None:
+        """
+        This functions sets up the middle-man for the data-passing subsystem
+        """
+        ctx = zmq.Context.instance()
+        incoming = ctx.socket(zmq.XSUB)
+        outgoing = ctx.socket(zmq.XPUB)
+
+        _, ports = self.db.get_comms_info('data')
+
+        # ports seem backwards because they should be here and only here
+        incoming.bind(f'tcp://*:{ports["send"]}')
+        outgoing.bind(f'tcp://*:{ports["recv"]}')
+
         while not self.event.is_set():
-            doc = None
-            hn = None
-            try:
-                with self.cv:
-                    self.cv.wait_for(predicate, timeout=dt)
-                    if len(self.dispatch_queue) > 0:
-                        doc = self.dispatch_queue.get_front()
-                        if (dt := (doc['time'] - time.time())) < min_dt:
-                            doc = self.dispatch_queue.pop_front()
-                    else:
-                        dt = dt_large
-                if doc is not None and dt < min_dt:
-                    if doc['to'] == 'hypervisor':
-                        self.process_command(doc['command'])
-                        continue
-                    if doc['to'] in self.known_devices and doc['to'] not in self.config['processes']['active']:
-                        self.logger.warning(f'Can\'t send "{doc["command"]}" to {doc["to"]} because it isn\'t online')
-                        continue
-                    hn, p = self.db.find_listener_address(doc['to'])
-                    self.logger.debug(f'Sending "{doc["command"]}" to {doc["to"]} at {hn}:{p}')
-                    with socket.create_connection((hn, p), timeout=0.1) as sock:
-                        sock.sendall(doc['command'].encode())
-            except Exception as e:
-                self.logger.warning(f'Dispatcher caught a {type(e)} while messaging {hn}: {e}')
-        self.logger.debug('Dispatcher shutting down')
+            zmq.proxy(incoming, outgoing)
+
+        # probably never get here
+        incoming.close()
+        outgoing.close()
+
+        return
+
+    def dispatcher(self, ping_period=5) -> None:
+        """
+        This function handles the command-passing communication subsystem
+        :param incoming_port: what port to listen on?
+        :param outgoing_port: what port to broadcast on?
+        :param ping_period: how often do pings happen? Default 5 (seconds)
+        """
+        ctx = zmq.Context.instance()
+
+        incoming = ctx.socket(zmq.REP)
+        outgoing = ctx.socket(zmq.PUB)
+
+        _, ports = self.db.get_comms_info('command')
+
+        # send/recv seems backwards because it is here. we "recv" on the
+        # line everyone else 'sends' on
+        incoming.bind(f'tcp://*:{ports["send"]}')
+        outgoing.bind(f'tpc://*:{ports["recv"]}')
+
+        poller = zmq.Poller()
+        poller.register(incoming, zmq.POLLIN)
+        last_ping = time.time()
+        queue = []
+        cmd_ack = {}
+
+        while not self.event.is_set():
+            next_ping = time.time() - last_ping + ping_period
+            next_command = queue[0][0] - time.time() if len(queue) > 0 else ping_period
+            timeout_ms = min(next_ping, next_command) * 1000
+            socks = dict(poller.poll(timeout=timeout_ms))
+
+            if (now := time.time()) - last_ping > ping_period or not len(socks):
+                # one ping only
+                outgoing.send_string("ping ")  # I think the space is necessary
+                last_ping = now
+            if socks.get(incoming) == zmq.POLLIN:
+                msg = incoming.recv_string()
+                incoming.send_string("")  # must reply
+                if msg.startswith('pong'):
+                    _, name = msg.split(' ')
+                    self.last_pong[name] = now
+                elif msg.startswith('{'):  # incoming external command
+                    try:
+                        doc = json.loads(msg)
+                        self.logger.debug(f'Incoming command from {doc["from"]}')
+                        heappush((float(doc['time']), doc['to'], doc['command']))
+                    except Exception as e:
+                        self.logger.debug(f'Caught a {type(e)} while processing. {e}')
+                        self.logger.debug(msg)
+                elif msg.startswith('ack'):  # command acknowledgement
+                    try:
+                        _, name, cmd_hash = msg.split(' ')
+                        del cmd_ack[cmd_hash]
+                    except KeyError:
+                        self.logger.debug(f'Unknown hash from {name}: {cmd_hash}')
+                    except Exception as e:
+                        self.logger.debug(f'Caught a {type(e)}: {e}')
+                        self.logger.debug(msg)
+                else:
+                    # Proabably an internal command from a pipeline?
+                    self.process_command(msg)
+            if len(queue) > 0 and queue[0][0]-now < 0.001:
+                _, to, cmd = heappop(queue)
+                if to == 'hypervisor':
+                    self.process_command(cmd)
+                else:
+                    cmd_hash = Doberman.utils.make_hash(now, to, cmd, hash_length=6)
+                    self.outgoing.send_string(f'{to} {cmd_hash} {cmd}')
+                    cmd_ack[cmd_hash] = (name, now())
+            pop = []
+            for h, (n, t) in cmd_ack.items():
+                if now - t > 5:
+                    self.logger.warning(f'Command to {n} hasn\'t been ack\'d in {now-t:.1f} sec')
+                    pop.append(h)
+            map(cmd_ack.pop, pop)
 
     def process_command(self, command: str) -> None:
         self.logger.debug(f'Processing {command}')
-        if command[0] == '{':
-            # a json document, this is for the dispatcher
-            with self.cv:
-                self.dispatch_queue.add(json.loads(command))
-                self.cv.notify()
-            return
-
         if command.startswith('start'):
             _, target = command.split(' ', maxsplit=1)
             self.logger.info(f'Hypervisor starting {target}')
@@ -275,6 +323,7 @@ class Hypervisor(Doberman.Monitor):
                 return
             self.logger.info(f'Hypervisor now managing {device}')
             self.update_config(manage=device)
+            self.last_restart[device] = dtnow()  # need this
 
         elif command.startswith('unmanage'):
             _, device = command.split(' ', maxsplit=1)
@@ -293,7 +342,7 @@ class Hypervisor(Doberman.Monitor):
                 self.run_over_ssh(host, f"screen -S {thing} -X quit")
             else:
                 # assume it's running on localhost?
-                self.run_over_ssh('localhost', f"screen -S {thing} -X quit")
+                self.run_locally(f"screen -S {thing} -X quit")
 
         else:
             self.logger.error(f'Command "{command}" not understood')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pymongo
 psutil
 requests
 python-dateutil
+zmq


### PR DESCRIPTION
Complete overhaul to the internal communication subsystem. New:
- Uses ZMQ rather than raw python sockets, because ZMQ allows us a variety of pre-defined topologies that are useful, and (more importantly) automatic reconnecting
- There are now two explicit avenues for communication: the "command" subsystem and the "data" subsystem. These differ in purpose and structure. The Listener class is replaced with a function that serves the purpose.
  - The "data" subsystem is a pub-sub topology with a central proxy broker (the HV). The HV binds to two ports and proxies between the Devices (which publish) and Pipelines (which subscribe).
  - The "command" subsystem is more complex. Commands and pings are sent out via pub-sub, but to receive acknowledgement (and new commands) a req-rep path is provided. Pings are published every 5 seconds, and processes respond with ack's on the req-rep line. If processes that have been running for more than a minute do not return a pong within 30 seconds, they get restarted. Commands now also come with a hash for tracking responses. The HV binds to the two ports necessary for this, which thus entirely removes the problems associated with dynamic port allocation, because there are now only 4 ports necessary and the HV binds to all of them.
- PipelineMonitors only partake in the command subsystem, with the Pipelines themselves joining the data subsystem. The SyncPipeline class has been modified to represent this. Additionally, Pipelines now run as threads exactly as SyncPipelines used to, which simplifies the handling.
- Some extra formatting stuff to at least marginally appease flake8.