### PR TITLE
Improve pipeline build logging

### DIFF
--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -162,7 +162,6 @@ class Monitor(object):
             if socks.get(incoming) == zmq.POLLIN:
                 msg = incoming.recv_string()
                 if msg.startswith('ping'):
-                    self.logger.debug(f'ping: {self.name}')
                     outgoing.send_string(f'pong {self.name}')
                     _ = outgoing.recv_string()
                 else:

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -162,6 +162,7 @@ class Monitor(object):
             if socks.get(incoming) == zmq.POLLIN:
                 msg = incoming.recv_string()
                 if msg.startswith('ping'):
+                    self.logger.debug(f'ping: {self.name}')
                     outgoing.send_string(f'pong {self.name}')
                     _ = outgoing.recv_string()
                 else:

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -155,6 +155,8 @@ class Pipeline(threading.Thread):
                     node_kwargs.update(kwargs)
                     try:
                         n = getattr(Doberman, node_type)(**node_kwargs)
+                    except AttributeError as e:
+                        raise ValueError(f'Node type "{node_type}" not implemented for node {kwargs["name"]}. Maybe you missed suffix "Node".')
                     except Exception as e:
                         self.logger.debug(f'Caught a {type(e)} while building {kwargs["name"]}: {e}')
                         self.logger.debug(f'Args: {node_kwargs}')


### PR DESCRIPTION
Give less cryptic error message (at least for a typical user) when a node type name is misspelt