### PR TITLE
Pipeline improvements

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -111,8 +111,7 @@ class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
         self.sensor_config_needed += ['alarm_thresholds', 'alarm_recurrence']
 
     def load_config(self, doc):
-        bufferlength = doc.pop('alarm_recurrence')
-        self.buffer.set_length(int(v))
+        doc.update(length=doc['alarm_recurrence'])
         super().load_config(doc)
 
     def process(self, packages):

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -110,6 +110,11 @@ class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
         self.strict = True
         self.sensor_config_needed += ['alarm_thresholds', 'alarm_recurrence']
 
+    def load_config(self, doc):
+        bufferlength = doc.pop('alarm_recurrence')
+        self.buffer.set_length(int(v))
+        super().load_config(doc)
+
     def process(self, packages):
         values = [p[self.input_var] for p in packages]
         low, high = self.config['alarm_thresholds']

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -17,6 +17,7 @@ class AlarmNode(Doberman.Node):
         self.auto_silence_duration = kwargs['silence_duration']
         self.messages_this_level = 0
         self.hash = None
+        self.sensor_config_needed = ['readout_interval']
 
     def escalate(self):
         """
@@ -75,6 +76,7 @@ class DeviceRespondingBase(AlarmNode):
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.accept_old = True
+        self.sensor_config_needed += ['alarm_recurrence']
 
     def process(self, package):
         # the 2 is a fudge factor
@@ -106,6 +108,7 @@ class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.strict = True
+        self.sensor_config_needed += ['alarm_thresholds', 'alarm_recurrence']
 
     def process(self, packages):
         values = [p[self.input_var] for p in packages]
@@ -137,6 +140,10 @@ class IntegerAlarmNode(AlarmNode):
     Integer status quantities are a fundamentally different thing from physical values.
     It makes sense to process them differently. The thresholds should be stored as [value, message] pairs.
     """
+    def setup(self, **kwargs):
+        super().setup(**kwargs)
+        self.sensor_config_needed += ['alarm_values']
+
     def process(self, package):
         value = int(package[self.input_var])
         for v, msg in self.config['alarm_values'].items():

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -139,7 +139,7 @@ class IntegerAlarmNode(AlarmNode):
     """
     def process(self, package):
         value = int(package[self.input_var])
-        for v, msg in self.config['alarm_thresholds'].items():
+        for v, msg in self.config['alarm_values'].items():
             if value == int(v):
                 self.log_alarm(f'Alarm for {self.description}: {msg}')
                 break

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -57,17 +57,24 @@ class AnalogControlNode(ControlNode):
         self.set_output(val)
 
 
-class PipelineControlNode(ControlNode):
+class PipelineControlNode(Doberman.Node):
     """
     Sometimes you want one pipeline to control another.
     """
+    def setup(self, **kwargs):
+        super().setup(**kwargs)
+        self.actions = kwargs['actions']
+
     def process(self, package):
-        for char in map(chr, range(ord('c'), ord('z')+1)):
+        """for char in map(chr, range(ord('c'), ord('z')+1)):
             if package.get(f'condition_{char}', False):
                 # do something
                 action, target = self.config.get(f'action_{char}', (None, None))
                 if action and target:
-                    self.control_pipeline(action, target)
+                    self.control_pipeline(action, target)"""
+        for condition, action in self.actions.items():
+            if package.get(condition, False):
+               self.control_pipeline(*action)
 
         if package.get('condition_test', False):
             # this one is mainly for testing
@@ -84,6 +91,7 @@ class PipelineControlNode(ControlNode):
             target = 'pl_convert'
         else:
             raise ValueError(f'Don\'t know what to do with pipeline {pipeline}')
+        self.logger.debug(f"Sending {action} to {pipeline}")
         self.pipeline.send_command(command=f'pipelinectl_{action} {pipeline}',
-                to=target, issuer=self.pipeline.name)
+                to=target)
 

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -66,12 +66,6 @@ class PipelineControlNode(Doberman.Node):
         self.actions = kwargs['actions']
 
     def process(self, package):
-        """for char in map(chr, range(ord('c'), ord('z')+1)):
-            if package.get(f'condition_{char}', False):
-                # do something
-                action, target = self.config.get(f'action_{char}', (None, None))
-                if action and target:
-                    self.control_pipeline(action, target)"""
         for condition, actions in self.actions.items():
             if package.get(condition, False):
                for action in actions:

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -72,9 +72,10 @@ class PipelineControlNode(Doberman.Node):
                 action, target = self.config.get(f'action_{char}', (None, None))
                 if action and target:
                     self.control_pipeline(action, target)"""
-        for condition, action in self.actions.items():
+        for condition, actions in self.actions.items():
             if package.get(condition, False):
-               self.control_pipeline(*action)
+               for action in actions:
+                   self.control_pipeline(*action)
 
         if package.get('condition_test', False):
             # this one is mainly for testing

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -11,7 +11,7 @@ class ControlNode(Doberman.Node):
         self.control_value = kwargs['control_value']
 
     def set_output(self, value, _force=False):
-        self.logger.debug(f'Setting output to {value}')
+        self.logger.debug(f'Setting {self.control_target} {self.control_value} to {value}')
         if not self.is_silent and not _force:
             self.pipeline.send_command(
                     command=f'set {self.control_value} {value}',
@@ -36,10 +36,10 @@ class DigitalControlNode(ControlNode):
             self.set_output(package[self.input_var])
         else:
             if package['condition_a']:
-                self.logger.info('Condition a met')
+                self.logger.info(f'{self.name}: condition a met')
                 self.set_output(self.config.get('output_a', 1))
             elif package['condition_b']:
-                self.logger.info('Condition b met')
+                self.logger.info(f'{self.name}: condition b met')
                 self.set_output(self.config.get('output_b', 0))
 
 

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -202,7 +202,7 @@ class SensorSourceNode(SourceNode):
         super().setup(**kwargs)
         if kwargs.get('new_value_required', False) or \
                 self.input_var.startswith('X_SYNC'):
-            self.pipeline.required_inputs.add(self.name)
+            self.pipeline.required_inputs.add(self.input_var)
 
     def receive_from_upstream(self, package):
         """

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -244,7 +244,7 @@ class BufferNode(Node):
 
     def load_config(self, doc):
         bufferlength = doc.pop('length')
-        self.buffer.set_length(int(v))
+        self.buffer.set_length(int(bufferlength))
         super().load_config(doc)
 
     def get_package(self):

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -50,7 +50,11 @@ class Node(object):
         else:  # ret is a number or something
             if isinstance(self, BufferNode):
                 package = package[-1]
-            package[self.output_var] = ret
+            try:
+                package[self.output_var] = ret
+            except TypeError:
+                # Presumably a cryptic unhashable type error
+                self.logger.warning(f"Bad value ({self.output_var}) of output_var for node {self.name}")
         self.send_downstream(package)
         self.post_process()
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -260,12 +260,14 @@ class Pipeline(threading.Thread):
                 this_node_config.update(doc.get(node.name, {}))
                 if isinstance(node, Doberman.AlarmNode):
                     rd = sensor_docs[node.input_var]
-                    this_node_config.update(
+                    for config_item in node.sensor_config_needed:
+                        this_node_config[config_item] = rd[config_item]
+                    """this_node_config.update(
                         alarm_thresholds=rd['alarm_thresholds'],
                         readout_interval=rd['readout_interval'],
                         alarm_recurrence=rd['alarm_recurrence'])
                     if isinstance(node, Doberman.SimpleAlarmNode):
-                        this_node_config.update(length=rd['alarm_recurrence'])
+                        this_node_config.update(length=rd['alarm_recurrence'])"""
                 node.load_config(this_node_config)
 
     def silence_for(self, duration, level=0):

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -262,12 +262,6 @@ class Pipeline(threading.Thread):
                     rd = sensor_docs[node.input_var]
                     for config_item in node.sensor_config_needed:
                         this_node_config[config_item] = rd[config_item]
-                    """this_node_config.update(
-                        alarm_thresholds=rd['alarm_thresholds'],
-                        readout_interval=rd['readout_interval'],
-                        alarm_recurrence=rd['alarm_recurrence'])
-                    if isinstance(node, Doberman.SimpleAlarmNode):
-                        this_node_config.update(length=rd['alarm_recurrence'])"""
                 node.load_config(this_node_config)
 
     def silence_for(self, duration, level=0):

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -31,8 +31,12 @@ class PipelineMonitor(Doberman.Monitor):
     def start_pipeline(self, name):
         if (doc := self.db.get_pipeline(name)) is None:
             self.logger.error(f'No pipeline named {name} found')
-            return -1
+            return
+        if (doc['status']=='active'):
+            self.logger.error(f'The pipeline named {name} is already active')
+            return
         self.logger.debug(f'starting pipeline {name}')
+        self.db.set_pipeline_value(name, [('status', 'active')])
         try:
             p = Doberman.Pipeline.create(doc, db=self.db,
                     logger=Doberman.utils.get_child_logger(name, self.db, self.logger),
@@ -40,11 +44,11 @@ class PipelineMonitor(Doberman.Monitor):
             p.build(doc)
         except Exception as e:
             self.logger.error(f'{type(e)}: {e}')
+            self.db.set_pipeline_value(name, [('status', 'inactive')])
             self.logger.error(f'Could not build pipeline {name}, check debug logs')
-            return -1
+            return
         self.register(obj=p, name=name)
         self.pipelines[p.name] = p
-        self.db.set_pipeline_value(name, [('status', 'active')])
         return 0
 
     def stop_pipeline(self, name):


### PR DESCRIPTION
Various small improvements to pipeline functioning (gets the PipelineControlNode working) and error reporting

- Refactors the sensor config loading for alarm nodes to be a little less obscure (and less of the slightly nasty isinstance checks)
- Alarms for the IntegerAlarmNode are now enumerated in the sensor under `alarm_values` rather than `alarm_thresholds`: cannot store different types of data under the same key in MongoDB
- Various logging messages now include the node name
- PipelineControlNode is now a subclass of Node, not ControlNode. Why? Because it doesn't make use of any of the ControlNode code, and indeed that gets in the way. They are fundamentally very different - ControlNode is designed for physical outputs.
- Rewrote the PipelineControlNode logic to allow (a) arbitrarily named conditions (because `condition_g` is much less meaningful than `tmp_is_in_error`) and (b) allow multiple actions to be carried out when one condition is true.
- Dedicated log message for when the `output_var` has an unhashable type. Why? It took me far too long to realise I had misspelt `output_var` as `ouput_var` and it was completely unclear where the error was coming from.
- SensorSourceNode now works with sync variables (there was a bug where it was looking for the wrong variable)