### PR TITLE
Avoiding a pipeline to be active twice

### DIFF
--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -31,10 +31,10 @@ class PipelineMonitor(Doberman.Monitor):
     def start_pipeline(self, name):
         if (doc := self.db.get_pipeline(name)) is None:
             self.logger.error(f'No pipeline named {name} found')
-            return -1
+            return
         if (self.db.get_pipeline_stats(name)['status']=='active'):
-            self.logger.error(f'The pipeline named {name} in already active')
-            return -1
+            self.logger.error(f'The pipeline named {name} is already active')
+            return
         self.logger.debug(f'starting pipeline {name}')
         self.db.set_pipeline_value(name, [('status', 'active')])
         try:
@@ -46,7 +46,7 @@ class PipelineMonitor(Doberman.Monitor):
             self.logger.error(f'{type(e)}: {e}')
             self.db.set_pipeline_value(name, [('status', 'inactive')])
             self.logger.error(f'Could not build pipeline {name}, check debug logs')
-            return -1
+            return
         self.register(obj=p, name=name)
         self.pipelines[p.name] = p
         return 0

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -32,7 +32,7 @@ class PipelineMonitor(Doberman.Monitor):
         if (doc := self.db.get_pipeline(name)) is None:
             self.logger.error(f'No pipeline named {name} found')
             return
-        if (self.db.get_pipeline_stats(name)['status']=='active'):
+        if (doc['status']=='active'):
             self.logger.error(f'The pipeline named {name} is already active')
             return
         self.logger.debug(f'starting pipeline {name}')


### PR DESCRIPTION
By checking if the pipeline is already active and activating it early on in the process, this might avoid getting a same pipeline activated multiple times

Could this be added to pipeline improvements or won't it work ?
I am not sure how to check because I don't know how to reproduce the error
I am not sure either if the "return -1" in line 37 would be the correct way to deal with an already active pipeline

Would solve #196 if it works