### PR TITLE
Alarm and pipeline tweaks

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -55,7 +55,7 @@ class AlarmNode(Doberman.Node):
         # Only send message if pipeline is silenced at base_level or above, 
         # or if it is silenced at level -1 (universal)
         if not self.is_silent or -1 < self.pipeline.silenced_at_level < self.base_level:
-            self.logger.debug(msg)
+            self.logger.error(msg)
             if self.hash is None:
                 self.hash = Doberman.utils.make_hash(ts or time.time(), self.pipeline.name)
                 self.alarm_start = ts or time.time()
@@ -73,7 +73,7 @@ class AlarmNode(Doberman.Node):
             except Exception as e:
                 self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
         else:
-            self.logger.error(msg)
+            self.logger.debug(msg)
 
 class DeviceRespondingBase(AlarmNode):
     """
@@ -85,7 +85,7 @@ class DeviceRespondingBase(AlarmNode):
         self.sensor_config_needed += ['alarm_recurrence']
 
     def process(self, package):
-        if (dt := ((now := time.time()) - package['time'])) > self.max_reading_delay:
+        if (dt := ((now := time.time()) - package['time'])) > self.config['readout_interval'] + self.max_reading_delay:
             self.log_alarm(
                 (f'Is {self.device} responding correctly? No new value for '
                  f'{self.input_var} has been seen in {int(dt)} seconds'),

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -11,6 +11,7 @@ class AlarmNode(Doberman.Node):
         self.description = kwargs['description']
         self.device = kwargs['device']
         self._log_alarm = kwargs['log_alarm']
+        self.max_reading_delay = kwargs['max_reading_delay']
         self.escalation_config = kwargs['escalation_config']
         self.escalation_level = 0
         self.base_level = kwargs['alarm_level']
@@ -79,9 +80,7 @@ class DeviceRespondingBase(AlarmNode):
         self.sensor_config_needed += ['alarm_recurrence']
 
     def process(self, package):
-        # the 2 is a fudge factor
-        dt_max = (2 + self.config['alarm_recurrence']) * self.config['readout_interval']
-        if (dt := ((now := time.time()) - package['time'])) > dt_max:
+        if (dt := ((now := time.time()) - package['time'])) > self.max_reading_delay:
             self.log_alarm(
                 (f'Is {self.device} responding correctly? No new value for '
                  f'{self.input_var} has been seen in {int(dt)} seconds'),

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -52,7 +52,9 @@ class AlarmNode(Doberman.Node):
         """
         Let the outside world know that something is going on
         """
-        if not self.is_silent or self.pipeline.silenced_at_level < self.base_level:
+        # Only send message if pipeline is silenced at base_level or above, 
+        # or if it is silenced at level -1 (universal)
+        if not self.is_silent or -1 < self.pipeline.silenced_at_level < self.base_level:
             self.logger.debug(msg)
             if self.hash is None:
                 self.hash = Doberman.utils.make_hash(ts or time.time(), self.pipeline.name)
@@ -60,13 +62,16 @@ class AlarmNode(Doberman.Node):
                 self.logger.warning(f'{self.name} beginning alarm with hash {self.hash}')
             self.escalate()
             level = self.base_level + self.escalation_level
-            if self._log_alarm(level=level,
-                               message=msg,
-                               pipeline=self.pipeline.name,
-                               _hash=self.hash):
-                # only self-silence if the message was successfully sent
+            try:
+                self._log_alarm(level=level,
+                                message=msg,
+                                pipeline=self.pipeline.name,
+                                _hash=self.hash)
+                # self-silence if the message was successfully sent
                 self.pipeline.silence_for(self.auto_silence_duration[level], self.base_level)
                 self.messages_this_level += 1
+            except Exception as e:
+                self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
         else:
             self.logger.error(msg)
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -74,7 +74,7 @@ class Pipeline(threading.Thread):
         status = 'silent' if self.cycles <= self.startup_cycles else doc['status']
         if status != 'silent':
             # reset
-            self.silenced_at_level = 0
+            self.silenced_at_level = -1
         timing = {}
         self.logger.debug(f'Pipeline {self.name} cycle {self.cycles}')
         drift = 0
@@ -264,7 +264,7 @@ class Pipeline(threading.Thread):
                         this_node_config[config_item] = rd[config_item]
                 node.load_config(this_node_config)
 
-    def silence_for(self, duration, level=0):
+    def silence_for(self, duration, level=-1):
         """
         Silence this pipeline for a set amount of time
         """

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -178,7 +178,7 @@ class Pipeline(threading.Thread):
                     setup_kwargs['write_to_influx'] = self.db.write_to_influx
                     setup_kwargs['send_to_pipelines'] = self.db.send_value_to_pipelines
                     setup_kwargs['log_alarm'] = getattr(self.monitor, 'log_alarm', None)
-                    for k in 'escalation_config silence_duration'.split():
+                    for k in 'escalation_config silence_duration max_reading_delay'.split():
                         setup_kwargs[k] = alarm_cfg[k]
                     setup_kwargs['get_pipeline_stats'] = self.db.get_pipeline_stats
                     setup_kwargs['cv'] = getattr(self, 'cv', None)

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -33,7 +33,7 @@ class PipelineMonitor(Doberman.Monitor):
             self.logger.error(f'No pipeline named {name} found')
             return
         if (doc['status']=='active'):
-            self.logger.error(f'The pipeline named {name} is already active')
+            self.logger.debug(f'The pipeline named {name} is already active')
             return
         self.logger.debug(f'starting pipeline {name}')
         self.db.set_pipeline_value(name, [('status', 'active')])

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -32,8 +32,8 @@ class PipelineMonitor(Doberman.Monitor):
         if (doc := self.db.get_pipeline(name)) is None:
             self.logger.error(f'No pipeline named {name} found')
             return
-        if (doc['status']=='active'):
-            self.logger.debug(f'The pipeline named {name} is already active')
+        if (doc['status'] != 'inactive'):
+            self.logger.debug(f'The pipeline named {name} is already started')
             return
         self.logger.debug(f'starting pipeline {name}')
         self.db.set_pipeline_value(name, [('status', 'active')])


### PR DESCRIPTION
  * Instead of computing a slightly arbitrary max reading delay from the bad recurrence, use a fixed value from the database. Why? Because this number represents our trust in readings arriving in a timely fashion, rather than anything to do with how often the sensor must be bad before issuing an alarm
  * Changed the way we check whether alarms were issued properly to use exceptions rather than return values (probably slightly more robust and certainly easier to keep track of - all exceptions are now caught only by the log_alarm function of AlarmNode before silencing the pipeline)
  * When the user presses silence on the website, the level is -1 (meaning universal for all pipelines) instead of 0 (previous default, only silencing level 0 alarms)
  * The start command doesn't reactivate silenced pipelines, which has lead to a couple of alarmstorms