### PR TITLE
Wait for LAN data rather than sleeping arbitrarily

### DIFF
--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -261,8 +261,6 @@ class LANDevice(Device):
     eol = '\r'
 
     def setup(self):
-        if not hasattr(self, 'msg_sleep'):
-            self.msg_sleep = 0.01
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -290,7 +290,6 @@ class LANDevice(Device):
             ret['retcode'] = -2
             return ret
 
-        starttime = time.time()
         try:
             # Read until we get the end-of-line character
             data = b''

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -256,6 +256,9 @@ class LANDevice(Device):
     """
     Class for LAN-connected devices
     """
+    msg_wait = 1.0 # Seconds to wait for response
+    recv_interval = 0.01 # Socket polling interval
+    eol = '\r'
 
     def setup(self):
         if not hasattr(self, 'msg_sleep'):
@@ -263,7 +266,7 @@ class LANDevice(Device):
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            self._device.settimeout(1)
+            self._device.settimeout(self.recv_interval)
             self._device.connect((self.ip, int(self.port)))
         except socket.error as e:
             raise ValueError(f'Couldn\'t connect to {self.ip}:{self.port}. Got a {type(e)}: {e}')
@@ -288,10 +291,22 @@ class LANDevice(Device):
             self.logger.fatal("Could not send message %s. Error: %s" % (message.strip(), e))
             ret['retcode'] = -2
             return ret
-        time.sleep(self.msg_sleep)
+        #time.sleep(self.msg_sleep)
 
+        starttime = time.time()
         try:
-            ret['data'] = self._device.recv(self.packet_bytes)
+            # Read until we get the end-of-line character
+            data = b''
+            for i in range(int(self.msg_wait / self.recv_interval)+1):
+                time.sleep(self.recv_interval)
+                try:
+                    data += self._device.recv(self.packet_bytes)
+                except socket.timeout:
+                    continue
+                if data.endswith(self.eol):
+                    break
+            ret['data'] = data
+            self.logger.debug(f"It took {time.time() - starttime:0.3f} s to get the data!")
         except socket.error as e:
             self.logger.fatal('Could not receive data from device. Error: %s' % e)
             ret['retcode'] = -2


### PR DESCRIPTION
Continue asking for data from LAN sensors until they send the end of line character, rather than waiting an arbitrary 1 second (or more). Also tidy up a bit and avoid functions just to set / override (constant) member variables. Fixes #83 (for ethernet sensors). We don't have any serial sensors any more, maybe we can close that issue?