### PR TITLE
Silence rework

### DIFF
--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -261,8 +261,6 @@ class LANDevice(Device):
     eol = '\r'
 
     def setup(self):
-        if not hasattr(self, 'msg_sleep'):
-            self.msg_sleep = 0.01
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -290,7 +290,6 @@ class LANDevice(Device):
             ret['retcode'] = -2
             return ret
 
-        starttime = time.time()
         try:
             # Read until we get the end-of-line character
             data = b''

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -256,6 +256,9 @@ class LANDevice(Device):
     """
     Class for LAN-connected devices
     """
+    msg_wait = 1.0 # Seconds to wait for response
+    recv_interval = 0.01 # Socket polling interval
+    eol = '\r'
 
     def setup(self):
         if not hasattr(self, 'msg_sleep'):
@@ -263,7 +266,7 @@ class LANDevice(Device):
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            self._device.settimeout(1)
+            self._device.settimeout(self.recv_interval)
             self._device.connect((self.ip, int(self.port)))
         except socket.error as e:
             raise ValueError(f'Couldn\'t connect to {self.ip}:{self.port}. Got a {type(e)}: {e}')
@@ -288,10 +291,22 @@ class LANDevice(Device):
             self.logger.fatal("Could not send message %s. Error: %s" % (message.strip(), e))
             ret['retcode'] = -2
             return ret
-        time.sleep(self.msg_sleep)
+        #time.sleep(self.msg_sleep)
 
+        starttime = time.time()
         try:
-            ret['data'] = self._device.recv(self.packet_bytes)
+            # Read until we get the end-of-line character
+            data = b''
+            for i in range(int(self.msg_wait / self.recv_interval)+1):
+                time.sleep(self.recv_interval)
+                try:
+                    data += self._device.recv(self.packet_bytes)
+                except socket.timeout:
+                    continue
+                if data.endswith(self.eol):
+                    break
+            ret['data'] = data
+            self.logger.debug(f"It took {time.time() - starttime:0.3f} s to get the data!")
         except socket.error as e:
             self.logger.fatal('Could not receive data from device. Error: %s' % e)
             ret['retcode'] = -2

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -38,9 +38,9 @@ class Node(object):
         """
         pass
 
-    def _process_base(self, status):
+    def _process_base(self, is_silent):
         self.logger.debug(f'{self.name} processing')
-        self.is_silent = status == 'silent'
+        self.is_silent = is_silent
         package = self.get_package()  # TODO discuss this wrt BufferNodes
         ret = self.process(package)
         if ret is None:

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -1,3 +1,5 @@
+import time
+
 import Doberman
 import collections
 
@@ -81,15 +83,14 @@ class PipelineMonitor(Doberman.Monitor):
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
                     self.logger.debug(f'Silencing {name}')
-                    self.db.set_pipeline_value(name, [('status', 'silent')])
+                    self.db.set_pipeline_value(name, [('silent_until', -1)])
             elif command.startswith('pipelinectl_active'):
                 _, name = command.split(' ')
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
                     self.logger.debug(f'Activating {name}')
-                    self.db.set_pipeline_value(name, [('status', 'active')])
-                    self.db.update_db('pipelines', {'name': name}, {'$unset': {'silent_until': 1}})
+                    self.db.set_pipeline_value(name, [('silent_until', time.time())])
             elif command == 'stop':
                 self.sh.event.set()
             else:


### PR DESCRIPTION
Currently, silencing works as follows:

- Set status to `silent`
- Put command into queue that activates pipeline again at a certain time in the future

The problem with this is, that you cannot easily prolong the silence period of a pipeline (Basically, you'd have to remove the initial reactivation command from the command queue which is a bit complicated). So I suggest the following:

- allowed values for a pipeline's status: 'active', 'inactive' (no more silent status)
- Wether or not a pipeline is silent is determined via the `silent_until` field in its DB doc. 
- if `silent_until > current time or  == -1 (silent forever)` the pipeline is silent else it's not

This should already include all the changes, but requires testing.
This change also needs a small tweak in doberview.