### PR TITLE
Enable test alarms and more reliable alarm sending

### DIFF
--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -159,18 +159,24 @@ class AlarmMonitor(Doberman.PipelineMonitor):
         """
         Sends 'message' to the contacts specified by 'level'.
         """
+        exception = None
         for protocol, recipients in self.db.get_contact_addresses(level).items():
-            if protocol == 'sms':
-                message = f'{self.db.experiment_name.upper()} {message}'
-                self.send_sms(recipients, message)
-            elif protocol == 'email':
-                subject = f'{self.db.experiment_name.capitalize()} level {level} alarm'
-                self.send_email(toaddr=recipients, subject=subject,
-                                message=message)
-            elif protocol == 'phone':
-                self.send_phonecall(recipients, message)
-            else:
-                raise ValueError(f"Couldn't send alarm message. Protocol {protocol} unknown.")
+            try:
+                if protocol == 'sms':
+                    message = f'{self.db.experiment_name.upper()} {message}'
+                    self.send_sms(recipients, message)
+                elif protocol == 'email':
+                    subject = f'{self.db.experiment_name.capitalize()} level {level} alarm'
+                    self.send_email(toaddr=recipients, subject=subject,
+                                    message=message)
+                elif protocol == 'phone':
+                    self.send_phonecall(recipients, message)
+                else:
+                    raise ValueError(f"Couldn't send alarm message. Protocol {protocol} unknown.")
+            except Exception as e:
+                exception = e # Save it for later but try other methods anyway
+        if exception is not None:
+            raise exception
 
     def check_shifters(self):
         """

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -16,6 +16,7 @@ class AlarmNode(Doberman.Node):
         self.escalation_level = 0
         self.base_level = kwargs['alarm_level']
         self.auto_silence_duration = kwargs['silence_duration']
+        self.silence_duration_cant_send = kwargs['silence_duration_cant_send']
         self.messages_this_level = 0
         self.hash = None
         self.sensor_config_needed = ['readout_interval']
@@ -72,6 +73,7 @@ class AlarmNode(Doberman.Node):
                 self.messages_this_level += 1
             except Exception as e:
                 self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
+                self.pipeline.silence_for(self.silence_duration_cant_send, self.base_level)
         else:
             self.logger.debug(msg)
 

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -261,8 +261,6 @@ class LANDevice(Device):
     eol = '\r'
 
     def setup(self):
-        if not hasattr(self, 'msg_sleep'):
-            self.msg_sleep = 0.01
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -256,6 +256,9 @@ class LANDevice(Device):
     """
     Class for LAN-connected devices
     """
+    msg_wait = 1.0 # Seconds to wait for response
+    recv_interval = 0.01 # Socket polling interval
+    eol = '\r'
 
     def setup(self):
         if not hasattr(self, 'msg_sleep'):
@@ -263,7 +266,7 @@ class LANDevice(Device):
         self.packet_bytes = 1024
         self._device = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            self._device.settimeout(1)
+            self._device.settimeout(self.recv_interval)
             self._device.connect((self.ip, int(self.port)))
         except socket.error as e:
             raise ValueError(f'Couldn\'t connect to {self.ip}:{self.port}. Got a {type(e)}: {e}')
@@ -288,10 +291,22 @@ class LANDevice(Device):
             self.logger.fatal("Could not send message %s. Error: %s" % (message.strip(), e))
             ret['retcode'] = -2
             return ret
-        time.sleep(self.msg_sleep)
+        #time.sleep(self.msg_sleep)
 
+        starttime = time.time()
         try:
-            ret['data'] = self._device.recv(self.packet_bytes)
+            # Read until we get the end-of-line character
+            data = b''
+            for i in range(int(self.msg_wait / self.recv_interval)+1):
+                time.sleep(self.recv_interval)
+                try:
+                    data += self._device.recv(self.packet_bytes)
+                except socket.timeout:
+                    continue
+                if data.endswith(self.eol):
+                    break
+            ret['data'] = data
+            self.logger.debug(f"It took {time.time() - starttime:0.3f} s to get the data!")
         except socket.error as e:
             self.logger.fatal('Could not receive data from device. Error: %s' % e)
             ret['retcode'] = -2

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -178,7 +178,7 @@ class Pipeline(threading.Thread):
                     setup_kwargs['write_to_influx'] = self.db.write_to_influx
                     setup_kwargs['send_to_pipelines'] = self.db.send_value_to_pipelines
                     setup_kwargs['log_alarm'] = getattr(self.monitor, 'log_alarm', None)
-                    for k in 'escalation_config silence_duration max_reading_delay'.split():
+                    for k in 'escalation_config silence_duration silence_duration_cant_send max_reading_delay'.split():
                         setup_kwargs[k] = alarm_cfg[k]
                     setup_kwargs['get_pipeline_stats'] = self.db.get_pipeline_stats
                     setup_kwargs['cv'] = getattr(self, 'cv', None)

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -57,6 +57,14 @@ class PipelineMonitor(Doberman.Monitor):
         self.stop_thread(name)
         del self.pipelines[name]
 
+    def testalarm(self, level):
+        message = f"This is a level {level} test alarm"
+        try:
+            self.log_alarm(level, message)
+        except Exception as e:
+            self.logger.error(f"Couldn't send level {level} alarm")
+            self.logger.debug(f"{type(e)}: {e}")
+
     def process_command(self, command):
         try:
             if command.startswith('pipelinectl_start'):
@@ -92,6 +100,10 @@ class PipelineMonitor(Doberman.Monitor):
                     self.db.update_db('pipelines', {'name': name}, {'$unset': {'silent_until': 1}})
             elif command == 'stop':
                 self.sh.event.set()
+            elif command.startswith('testalarm'):
+                _, level = command.split(' ')
+                self.logger.debug(f'Sending level {level} test alarm')
+                self.testalarm(int(level))
             else:
                 self.logger.info(f'I don\'t understand command "{command}"')
         except Exception as e:


### PR DESCRIPTION
Allows sending a test alarm by passing the 'testalarm [LEVEL]' command to the alarm pipeline monitor.

Also fixes a bug in the alarm sending whereby if one communication mechanism doesn't work (e.g. email fails) the others may not be tried, depending one what order the connection details are stored in the database. Now all are tried and an exception is nevertheless raised if one fails by log_alarm in AlarmMonitor.py.

In AlarmNode.log_alarm the exception is caught and an additional database parameter (silence_duration_cant_send) determines how long the pipeline should be silenced (to avoid sending a new alarm for every subsequent reading if there is still a problem.

For now, for pancake, this is set to 60 seconds.