### PR TITLE
Shutdown sequence

### DIFF
--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -213,7 +213,6 @@ class SensorSourceNode(SourceNode):
         super().receive_from_upstream(package)
 
 
-
 class PipelineSourceNode(SourceNode):
     """
     A node to source info about another pipeline.

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -41,7 +41,7 @@ class Pipeline(threading.Thread):
         Creates a pipeline and returns it
         """
         for node in config['pipeline']:
-            if node['type'] == 'SensorSourceNode':
+            if node['type'] in ['SensorSourceNode', 'DeviceRespondingSyncNode']:
                 return SyncPipeline(**kwargs)
         return Pipeline(**kwargs)
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -305,12 +305,14 @@ class SyncPipeline(Pipeline):
         host, ports = self.db.get_comms_info('data')
         socket.connect(f'tcp://{host}:{ports["recv"]}')
         for name in self.depends_on:
+            self.logger.debug(f'listening to {name}')
             socket.setsockopt_string(zmq.SUBSCRIBE, name)
         poller = zmq.Poller()
         poller.register(socket, zmq.POLLIN)
         has_new = set()
         while not self.event.is_set():
             socks = dict(poller.poll(timeout=1000))
+            self.logger.debug(f'I am here {socks = }')
             if socks.get(socket) == zmq.POLLIN:
                 try:
                     msg = None

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -312,7 +312,6 @@ class SyncPipeline(Pipeline):
         has_new = set()
         while not self.event.is_set():
             socks = dict(poller.poll(timeout=1000))
-            self.logger.debug(f'I am here {socks = }')
             if socks.get(socket) == zmq.POLLIN:
                 try:
                     msg = None

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -70,8 +70,8 @@ class Hypervisor(Doberman.Monitor):
 
     def shutdown(self) -> None:
         # shut dow the pipeline monitors
-        for thing in 'alarm_monitor control_pipeline convert_pipeline'.split():
-            self.run_locally(f"screen -S {thing} -X quit")
+        for thing in 'alarm control convert'.split():
+            self.run_locally(f"screen -S pl_{thing} -X quit")
             self.update_config(unactive=f'pl_{thing}')
             time.sleep(0.1)
         managed = self.config['processes']['managed']

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -37,6 +37,7 @@ class Hypervisor(Doberman.Monitor):
         path = self.config['path']
         for thing in 'alarm control convert'.split():
             self.run_locally(f'cd {path} && ./start_process.sh --{thing}')
+            self.last_pong[f'pl_{thing}'] = time.time()
             time.sleep(0.1)
         # now start the rest of the things
         self.known_devices = self.db.distinct('devices', 'name')
@@ -106,7 +107,7 @@ class Hypervisor(Doberman.Monitor):
         if active:
             updates['$addToSet'] = {'processes.active': active}
         if unactive:
-            updates['$pull'] = {'processes.active': active}
+            updates['$pull'] = {'processes.active': unactive}
         if heartbeat:
             updates['$set']: {'heartbeat': heartbeat}
         if status:

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -72,6 +72,7 @@ class Hypervisor(Doberman.Monitor):
         # shut dow the pipeline monitors
         for thing in 'alarm_monitor control_pipeline convert_pipeline'.split():
             self.run_locally(f"screen -S {thing} -X quit")
+            self.update_config(unactive=f'pl_{thing}')
             time.sleep(0.1)
         managed = self.config['processes']['managed']
         for device in managed:

--- a/scripts/start_process.sh
+++ b/scripts/start_process.sh
@@ -8,17 +8,17 @@ x=0
 while [[ $1 =~ ^- && ! $1 == '--' ]]; do case $1 in
   --alarm )
     target="alarm"
-    screen_name="alarm_monitor"
+    screen_name="pl_alarm"
     x=$((x+1))
     ;;
   --control )
     target="control"
-    screen_name="control_pipeline"
+    screen_name="pl_control"
     x=$((x+1))
     ;;
   --convert )
     target="convert"
-    screen_name="convert_pipeline"
+    screen_name="pl_convert"
     x=$((x+1))
     ;;
   -d | --device )


### PR DESCRIPTION
Improvements to the shutdown sequence of the hypervisor.
Keyboard interrupt the hypervisor will now close all three pipeline monitors and all managed devices. 
Also seems to fix #192. At least, I don't observe this issue anymore. 