### PR TITLE
Custom control node inputs

### DIFF
--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -38,11 +38,9 @@ class DigitalControlNode(ControlNode):
             if package[self.input_var[0]]:
                 self.logger.info(f'{self.name}: opening')
                 self.set_output(1)
-                #self.set_output(self.config.get('output_a', 1))
             elif package[self.input_var[1]]:
                 self.logger.info(f'{self.name}: closing')
                 self.set_output(0)
-                #self.set_output(self.config.get('output_b', 0))
 
 
 class AnalogControlNode(ControlNode):

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -35,12 +35,14 @@ class DigitalControlNode(ControlNode):
         if self.one_input:
             self.set_output(package[self.input_var])
         else:
-            if package['condition_a']:
-                self.logger.info(f'{self.name}: condition a met')
-                self.set_output(self.config.get('output_a', 1))
-            elif package['condition_b']:
-                self.logger.info(f'{self.name}: condition b met')
-                self.set_output(self.config.get('output_b', 0))
+            if package[self.input_var[0]]:
+                self.logger.info(f'{self.name}: opening')
+                self.set_output(1)
+                #self.set_output(self.config.get('output_a', 1))
+            elif package[self.input_var[1]]:
+                self.logger.info(f'{self.name}: closing')
+                self.set_output(0)
+                #self.set_output(self.config.get('output_b', 0))
 
 
 class AnalogControlNode(ControlNode):


### PR DESCRIPTION
Sometimes having just condition_a and condition_b hardcoded is not enough (if you want multiple control nodes in one pipeline). Probably better to make them a config option.

Note this is not backwards compatible for non-single-input control nodes so their config would need updating