### PR TITLE
Remote hb pipeline

### DIFF
--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -155,12 +155,14 @@ class AlarmMonitor(Doberman.PipelineMonitor):
                 raise RuntimeError(f"Couldn't send message, status {response.status_code}: "
                                   f"{response.content.decode('ascii')}")
 
-    def log_alarm(self, level=None, message=None, pipeline=None, _hash=None):
+    def log_alarm(self, level=None, message=None, pipeline=None, _hash=None, prot_rec_dict=None):
         """
         Sends 'message' to the contacts specified by 'level'.
         """
         exception = None
-        for protocol, recipients in self.db.get_contact_addresses(level).items():
+        if not prot_rec_dict:
+            prot_rec_dict = self.db.get_contact_addresses(level)
+        for protocol, recipients in prot_rec_dict.items():
             try:
                 if protocol == 'sms':
                     message = f'{self.db.experiment_name.upper()} {message}'

--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -162,6 +162,7 @@ class AlarmMonitor(Doberman.PipelineMonitor):
         exception = None
         if not prot_rec_dict:
             prot_rec_dict = self.db.get_contact_addresses(level)
+        self.logger.debug(f'{prot_rec_dict = }')
         for protocol, recipients in prot_rec_dict.items():
             try:
                 if protocol == 'sms':

--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -162,7 +162,6 @@ class AlarmMonitor(Doberman.PipelineMonitor):
         exception = None
         if not prot_rec_dict:
             prot_rec_dict = self.db.get_contact_addresses(level)
-        self.logger.debug(f'{prot_rec_dict = }')
         for protocol, recipients in prot_rec_dict.items():
             try:
                 if protocol == 'sms':

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -110,7 +110,8 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             timestamp, numbers_string = f.read().split('\n', maxsplit=1)
             numbers = numbers_string.strip().split(',')
             if dt := (time.time() - int(timestamp)) > float(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
-                msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {int(dt/60)} minutes."
+                self.logger.debug(f'{dt = }')
+                msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {round(dt/60)} minutes."
                 prd = {'sms': numbers}
                 if dt > float(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms
                     prd['phone'] = numbers

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -141,7 +141,9 @@ class DeviceRespondingInfluxNode(DeviceRespondingBase, Doberman.InfluxSourceNode
 
 
 class DeviceRespondingSyncNode(DeviceRespondingBase, Doberman.SensorSourceNode):
-    pass
+    def setup(self, **kwargs):
+        super().setup(**kwargs)
+        self.creates_sync_pipelines = True
 
 
 class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -110,7 +110,7 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             timestamp, numbers_string = f.read().split('\n', maxsplit=1)
             numbers = numbers_string.strip().split(',')
             dt = time.time() - int(timestamp)
-            if dt  > int(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
+            if dt > int(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
                 msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {round(dt/60)} minutes."
                 prd = {'sms': numbers}
                 if dt > int(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -116,6 +116,8 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
                 if dt > int(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms
                     prd['phone'] = numbers
                 self.log_alarm(msg, prd)
+            else:
+                self.logger.debug(f'Last remote heartbeat from {experiment_name} was {int(dt)} seconds ago.')
 
 class DeviceRespondingBase(AlarmNode):
     """

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -144,7 +144,7 @@ class DeviceRespondingInfluxNode(DeviceRespondingBase, Doberman.InfluxSourceNode
 
 
 class DeviceRespondingSyncNode(DeviceRespondingBase, Doberman.SensorSourceNode):
-   pass
+    pass
 
 class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
     """

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -95,10 +95,10 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
                                 pipeline=self.pipeline.name,
                                 prot_rec_dict=prd,)
                 # self-silence if the message was successfully sent
-                self.pipeline.silence_for(int(self.config.get('silence_duration', 300), -1))
+                self.pipeline.silence_for(int(self.config.get('silence_duration', 300)), -1)
             except Exception as e:
                 self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
-                self.pipeline.silence_for(self.config.get('silence_duration', 300), -1)
+                self.pipeline.silence_for(int(self.config.get('silence_duration', 300)), -1)
         else:
             self.logger.debug(msg)
 
@@ -111,7 +111,6 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             numbers = numbers_string.strip().split(',')
             dt = time.time() - int(timestamp)
             if dt  > int(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
-                self.logger.debug(f'{dt = }')
                 msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {round(dt/60)} minutes."
                 prd = {'sms': numbers}
                 if dt > int(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -93,7 +93,7 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             try:
                 self._log_alarm(message=msg,
                                 pipeline=self.pipeline.name,
-                                prot_rect_dict=prd,)
+                                prot_rec_dict=prd,)
                 # self-silence if the message was successfully sent
                 self.pipeline.silence_for(self.config.get('silence_duration', 300), -1)
             except Exception as e:

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -144,8 +144,7 @@ class DeviceRespondingInfluxNode(DeviceRespondingBase, Doberman.InfluxSourceNode
 
 
 class DeviceRespondingSyncNode(DeviceRespondingBase, Doberman.SensorSourceNode):
-    def setup(self, **kwargs):
-        super().setup(**kwargs)
+   pass
 
 class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
     """

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -143,8 +143,6 @@ class DeviceRespondingInfluxNode(DeviceRespondingBase, Doberman.InfluxSourceNode
 class DeviceRespondingSyncNode(DeviceRespondingBase, Doberman.SensorSourceNode):
     def setup(self, **kwargs):
         super().setup(**kwargs)
-        self.creates_sync_pipelines = True
-
 
 class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
     """

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -146,6 +146,7 @@ class DeviceRespondingInfluxNode(DeviceRespondingBase, Doberman.InfluxSourceNode
 class DeviceRespondingSyncNode(DeviceRespondingBase, Doberman.SensorSourceNode):
     pass
 
+
 class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
     """
     A simple alarm. Checks a value against the thresholds stored in its sensor document.

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -109,10 +109,10 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
         with open(f'{directory}/remote_hb_{experiment_name}', 'r') as f:
             timestamp, numbers_string = f.read().split('\n', maxsplit=1)
             numbers = numbers_string.strip().split(',')
-            if dt := (time.time() - int(timestamp)) > self.config.get('max_delay_sms', 3*60): # default 3 minutes for sms
+            if dt := (time.time() - int(timestamp)) > float(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
                 msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {int(dt/60)} minutes."
                 prd = {'sms': numbers}
-                if dt > self.config.get('max_delay_phone', 10*60): # and 10 minutes for phone + sms
+                if dt > float(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms
                     prd['phone'] = numbers
                 self.log_alarm(msg, prd)
 

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -109,11 +109,12 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
         with open(f'{directory}/remote_hb_{experiment_name}', 'r') as f:
             timestamp, numbers_string = f.read().split('\n', maxsplit=1)
             numbers = numbers_string.strip().split(',')
-            if dt := (time.time() - int(timestamp)) > float(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
+            dt = time.time() - int(timestamp)
+            if dt  > int(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
                 self.logger.debug(f'{dt = }')
                 msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {round(dt/60)} minutes."
                 prd = {'sms': numbers}
-                if dt > float(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms
+                if dt > int(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms
                     prd['phone'] = numbers
                 self.log_alarm(msg, prd)
 

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -105,7 +105,7 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
     def process(self, package):
 
         directory = self.config.get('directory', '/scratch')
-        experiment_name = self.config.get('experiment_name]')
+        experiment_name = self.config.get('experiment_name')
         with open(f'{directory}/remote_hb_{experiment_name}', 'r') as f:
             timestamp, numbers_string = f.read().split('\n', maxsplit=1)
             numbers = numbers_string.strip().split(',')

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -95,7 +95,7 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
                                 pipeline=self.pipeline.name,
                                 prot_rec_dict=prd,)
                 # self-silence if the message was successfully sent
-                self.pipeline.silence_for(self.config.get('silence_duration', 300), -1)
+                self.pipeline.silence_for(int(self.config.get('silence_duration', 300), -1))
             except Exception as e:
                 self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
                 self.pipeline.silence_for(self.config.get('silence_duration', 300), -1)

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -153,6 +153,7 @@ class Device(object):
         """
         Implemented by a child class
         """
+        return None
 
     def close(self):
         self.event.set()

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -45,7 +45,6 @@ class Monitor(object):
         Joins all running threads
         """
         self.event.set()
-        self.shutdown()
         pop = []
         with self.lock:
             for t in self.threads.values():
@@ -60,6 +59,7 @@ class Monitor(object):
                 else:
                     pop.append(n)
         map(self.threads.pop, pop)
+        self.shutdown()
         self.db.notify_hypervisor(inactive=self.name)
 
     def register(self, name, obj, period=None, _no_stop=False, **kwargs):

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -18,7 +18,6 @@ class Node(object):
         self.downstream_nodes = []
         self.config = {}
         self.is_silent = True
-        self.creates_sync_pipelines = False
         self.logger.debug(f'{name} constructor')
 
     def __del__(self):
@@ -202,7 +201,6 @@ class SensorSourceNode(SourceNode):
 
     def setup(self, **kwargs):
         super().setup(**kwargs)
-        self.creates_sync_pipelines = True
         if kwargs.get('new_value_required', False) or \
                 self.input_var.startswith('X_SYNC'):
             self.pipeline.required_inputs.add(self.input_var)

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -18,6 +18,7 @@ class Node(object):
         self.downstream_nodes = []
         self.config = {}
         self.is_silent = True
+        self.creates_sync_pipelines = False
         self.logger.debug(f'{name} constructor')
 
     def __del__(self):
@@ -201,6 +202,7 @@ class SensorSourceNode(SourceNode):
 
     def setup(self, **kwargs):
         super().setup(**kwargs)
+        self.creates_sync_pipelines = True
         if kwargs.get('new_value_required', False) or \
                 self.input_var.startswith('X_SYNC'):
             self.pipeline.required_inputs.add(self.input_var)

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -41,7 +41,7 @@ class Pipeline(threading.Thread):
         Creates a pipeline and returns it
         """
         for node in config['pipeline']:
-            if node.creates_sync_pipelines:
+            if node['type'] in ['SensorSourceNode', 'DeviceRespondingSyncNode']:
                 return SyncPipeline(**kwargs)
         return Pipeline(**kwargs)
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -41,7 +41,7 @@ class Pipeline(threading.Thread):
         Creates a pipeline and returns it
         """
         for node in config['pipeline']:
-            if node['type'] in ['SensorSourceNode', 'DeviceRespondingSyncNode']:
+            if node.creates_sync_pipelines:
                 return SyncPipeline(**kwargs)
         return Pipeline(**kwargs)
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -170,10 +170,8 @@ class Pipeline(threading.Thread):
                             raise ValueError(f'Invalid input_var for {n.name}: {kwargs["input_var"]}')
                         for field in fields:
                             setup_kwargs[field] = doc.get(field)
-                    elif isinstance(n, (Doberman.InfluxSinkNode)):
-                        if (
-                                doc := self.db.get_sensor_setting(
-                                    name=kwargs.get('output_var', kwargs['input_var']))) is None:
+                    elif isinstance(n, Doberman.InfluxSinkNode):
+                        if (doc := self.db.get_sensor_setting(name=kwargs.get('output_var', kwargs['input_var']))) is None:
                             raise ValueError(f'Invalid output_var for {n.name}: {kwargs.get("output_var")}')
                         for field in fields:
                             setup_kwargs[field] = doc.get(field)

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -83,7 +83,6 @@ class Hypervisor(Doberman.Monitor):
             self.stop_device(device)
             time.sleep(0.05)
 
-
     def sync_signals(self, periods: list) -> None:
         ctx = zmq.Context.instance()
         socket = ctx.socket(zmq.PUB)

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -48,11 +48,9 @@ class Hypervisor(Doberman.Monitor):
         self.broker = threading.Thread(target=self.data_broker, args=(self.broker_context,))
         self.broker.start()
         self.register(obj=self.compress_logs, period=86400, name='log_compactor', _no_stop=True)
-        if (rhb := self.config.get('remote_heartbeat', {}).get('status', '')) == 'send':
-            self.register(obj=self.send_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
-        elif rhb == 'receive':
-            self.register(obj=self.check_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True)
-
+        rhbs = self.config.get('remote_heartbeat', {})
+        for doc in rhbs.get('send', []):
+            self.register(obj=self.send_remote_heartbeat, period=60, name='remote_heartbeat', _no_stop=True, config=doc)
         time.sleep(1)
 
         # start the fixed-frequency sync signals
@@ -72,7 +70,7 @@ class Hypervisor(Doberman.Monitor):
         # shut dow the pipeline monitors
         for thing in 'alarm control convert'.split():
             self.run_locally(f"screen -S pl_{thing} -X quit")
-            self.update_config(unactive=f'pl_{thing}')
+            self.update_config(deactivate=f'pl_{thing}')
             time.sleep(0.1)
         managed = self.config['processes']['managed']
         for device in managed:
@@ -99,16 +97,16 @@ class Hypervisor(Doberman.Monitor):
             socket.send_string(f'X_SYNC_{p} {now:.3f} 0')
             heappush(q, (now+p, p))
 
-    def update_config(self, unmanage=None, manage=None, active=None, unactive=None, heartbeat=None, status=None) -> None:
+    def update_config(self, unmanage=None, manage=None, activate=None, deactivate=None, heartbeat=None, status=None) -> None:
         updates = {}
         if unmanage:
             updates['$pull'] = {'processes.managed': unmanage}
         if manage:
             updates['$addToSet'] = {'processes.managed': manage}
-        if active:
-            updates['$addToSet'] = {'processes.active': active}
-        if unactive:
-            updates['$pull'] = {'processes.active': unactive}
+        if activate:
+            updates['$addToSet'] = {'processes.active': activate}
+        if deactivate:
+            updates['$pull'] = {'processes.active': deactivate}
         if heartbeat:
             updates['$set']: {'heartbeat': heartbeat}
         if status:
@@ -152,24 +150,19 @@ class Hypervisor(Doberman.Monitor):
         self.update_config(heartbeat=dtnow())
         return self.config['period']
 
-    def send_remote_heartbeat(self) -> None:
+    def send_remote_heartbeat(self, config) -> None:
         # touch a file on a remote server just so someone else knows we're still alive
         numbers = []
         for doc in self.db.read_from_db('contacts', {'on_shift': True}):
             numbers.append(doc['sms'])
-        if (addr := self.config.get('remote_heartbeat', {}).get('address')) is not None:
-            self.run_over_ssh(addr, r'date +%s > /scratch/remote_hb_'+self.db.experiment_name,
+        if (addr := config.get('address')) is not None:
+            directory = config.get('directory', '/scratch')
+            self.run_over_ssh(addr,
+                              r'date +%s > ' + directory + '/remote_hb_' + self.db.experiment_name,
+                              port=config.get('port', 22))
+            self.run_over_ssh(addr,
+                              r'echo "' + ','.join(numbers) + '" >> ' + directory + '/remote_hb_' + self.db.experiment_name,
                               port=self.config['remote_heartbeat'].get('port', 22))
-            self.run_over_ssh(addr, r'echo "' + ','.join(numbers) + '" >> /scratch/remote_hb_' + self.db.experiment_name,
-                              port=self.config['remote_heartbeat'].get('port', 22))
-
-    def check_remote_heartbeat(self) -> None:
-        for p in os.listdir('/scratch/remote_hb_*'):
-            with open(f'/scratch/{p}', 'r') as f:
-                time_str = f.read().strip()
-            if time.time() - int(time_str) > 3*60:
-                # timestamp is too old, the other server is having problems
-                self.db.log_alarm(msg=f"{p.split('_',maxsplit=2)[3]} hasn't heartbeated recently, maybe let someone know?")
 
     def run_over_ssh(self, address: str, command: str, port=22) -> int:
         """
@@ -220,7 +213,7 @@ class Hypervisor(Doberman.Monitor):
     def stop_device(self, device: str) -> int:
         doc = self.db.get_device_setting(device)
         host = doc['host']
-        self.update_config(unactive=device)
+        self.update_config(deactivate=device)
         command = f"screen -S {device} -X quit"
         if host == self.localhost:
             return self.run_locally(command)


### PR DESCRIPTION
I implemented the `check_remote_heartbeat` part. 

- New node type`CheckRemoteHeartbeatNode` can be used in pipelines. Most likely you want one of the SYNC signals to be the input to give the period (i.e. execute the check every 60 seconds). Like this, silencing, reactivating, etc. of remote heartbeat alarms becomes trivial. 
- depending on `max_delay_sms` and `max_delay_phone` it then send SMS and phone calls to the shifters numbers in the remote_hb document. Like this, you reach the shifters of the remote experiment and don't have to rely on someone of the local experiment, which might not have shifters at this point or whatever.

Also addresses one of the comments of the experimental -> master PR and changes again a bit the shutdown sequence of the hypervisor since it could happen before that device got automatically restarted during the sequence.


TODO: update documentation