### PR TITLE
Don't deactivate pipeline when shutting down PipelineMonitor

### DIFF
--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -45,9 +45,11 @@ class Pipeline(threading.Thread):
                 return SyncPipeline(**kwargs)
         return Pipeline(**kwargs)
 
-    def stop(self):
+    def stop(self, keep_status=False):
         self.event.set()
         try:
+            if not keep_status:
+                self.db.set_pipeline_value(self.name, [('status', 'inactive')])
             for pl in self.subpipelines:
                 for node in pl:
                     try:

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -48,7 +48,6 @@ class Pipeline(threading.Thread):
     def stop(self):
         self.event.set()
         try:
-            self.db.set_pipeline_value(self.name, [('status', 'inactive')])
             for pl in self.subpipelines:
                 for node in pl:
                     try:

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -56,7 +56,7 @@ class PipelineMonitor(Doberman.Monitor):
 
     def stop_pipeline(self, name):
         self.logger.debug(f'stopping pipeline {name}')
-        self.pipelines[name].stop()
+        self.pipelines[name].stop(keep_status=True)
         self.stop_thread(name)
         del self.pipelines[name]
 

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -28,7 +28,7 @@ class PipelineMonitor(Doberman.Monitor):
     def shutdown(self):
         self.logger.debug(f'{self.name} shutting down')
         for p in list(self.pipelines.keys()):
-            self.stop_pipeline(p)
+            self.stop_pipeline(p, keep_status=True)
 
     def start_pipeline(self, name):
         if (doc := self.db.get_pipeline(name)) is None:
@@ -54,9 +54,9 @@ class PipelineMonitor(Doberman.Monitor):
         self.pipelines[p.name] = p
         return 0
 
-    def stop_pipeline(self, name):
+    def stop_pipeline(self, name, keep_status=False):
         self.logger.debug(f'stopping pipeline {name}')
-        self.pipelines[name].stop(keep_status=True)
+        self.pipelines[name].stop(keep_status=keep_status)
         self.stop_thread(name)
         del self.pipelines[name]
 


### PR DESCRIPTION
Maybe this was the cause for #225 - hard to tell from the given information. Was intended as a feature, but I guess it's better when all the same pipelines start up again after someone shuts down the PipelineMonitor. 