### PR TITLE
Better logging

### DIFF
--- a/Doberman/AlarmMonitor.py
+++ b/Doberman/AlarmMonitor.py
@@ -52,7 +52,7 @@ class AlarmMonitor(Doberman.PipelineMonitor):
             message = ' '.join(message[:maxmessagelength + 1].split(' ')[0:-1])
             message = '<p>' + message + '</p>'
             message += '<p>Message shortened.</p>'
-            self.logger.warning(f"Message exceeds {maxmessagelength} characters. Message will be shortened.")
+            self.logger.info(f"Message exceeds {maxmessagelength} characters. Message will be shortened.")
         message = f"This is the {self.db.experiment_name} alarm system. " + message
         if isinstance(phone_numbers, str):
             phone_numbers = [phone_numbers]
@@ -138,7 +138,7 @@ class AlarmMonitor(Doberman.PipelineMonitor):
         # Long messages are shortened to avoid excessive fees
         if len(message) > maxmessagelength:
             message = ' '.join(message[:maxmessagelength + 1].split(' ')[0:-1])
-            self.logger.warning(f"Message exceeds {maxmessagelength} characters. Message will be shortened.")
+            self.logger.info(f"Message exceeds {maxmessagelength} characters. Message will be shortened.")
         if isinstance(phone_numbers, str):
             phone_numbers = [phone_numbers]
         self.logger.warning(f'Sending SMS to {len(phone_numbers)} recipient{"s" if len(phone_numbers)>1 else ""}')

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -75,6 +75,8 @@ class AlarmNode(Doberman.Node):
             except Exception as e:
                 self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
                 self.pipeline.silence_for(self.silence_duration_cant_send, self.config['alarm_level'])
+        else:
+            self.logger.debug(msg)
 
 
 class CheckRemoteHeartbeatNode(Doberman.Node):
@@ -101,6 +103,8 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             except Exception as e:
                 self.logger.error(f"Exception sending alarm: {type(e)}, {e}.")
                 self.pipeline.silence_for(int(self.config.get('silence_duration', 300)), -1)
+        else:
+            self.logger.debug(msg)
 
     def process(self, package):
         directory = self.config.get('directory', '/scratch')

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -36,9 +36,9 @@ class AlarmNode(Doberman.Node):
             self.escalation_level = min(max_total_level - self.config['alarm_level'], self.escalation_level + 1)
             self.messages_this_level = 0  # reset count so we don't escalate again immediately
         else:
-            self.logger.info((f'{self.name} at level {self.config["alarm_level"]}/{self.escalation_level} '
-                              f'for {self.messages_this_level} messages, need {self.escalation_config[total_level]} '
-                              f'to escalate'))
+            self.logger.warning((f'{self.name} at level {self.config["alarm_level"]}/{self.escalation_level} '
+                                 f'for {self.messages_this_level} messages, need {self.escalation_config[total_level]} '
+                                 f'to escalate'))
 
     def reset_alarm(self):
         """

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -79,6 +79,7 @@ class Device(object):
                     if len(self.cmd_queue) > 0:
                         command, ret = self.cmd_queue.pop(0)
                 if command is not None:
+                    self.logger.debug(f'Executing {command}')
                     t_start = time.time()  # we don't want perf_counter because we care about
                     pkg = self.send_recv(command)
                     t_stop = time.time()  # the clock time when the data came out not cpu time

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -22,7 +22,7 @@ class Device(object):
         """
         opts is the document from the database
         """
-        logger.debug('Device base ctor')
+        logger.info('Device base ctor')
         if 'address' in opts:
             for k, v in opts['address'].items():
                 setattr(self, k, v)

--- a/Doberman/BaseDevice.py
+++ b/Doberman/BaseDevice.py
@@ -1,6 +1,5 @@
 try:
     import serial
-
     has_serial = True
 except ImportError:
     has_serial = False
@@ -71,7 +70,7 @@ class Device(object):
         function that should call send_recv to avoid issues with simultaneous
         access (ie, the isThisMe routine avoids this)
         """
-        self.logger.debug('Readout scheduler starting')
+        self.logger.info('Readout scheduler starting')
         while not self.event.is_set():
             try:
                 command = None
@@ -91,7 +90,7 @@ class Device(object):
                             cv.notify()
             except Exception as e:
                 self.logger.error(f'Scheduler caught a {type(e)} while processing {command}: {e}')
-        self.logger.debug('Readout scheduler returning')
+        self.logger.info('Readout scheduler returning')
 
     def add_to_schedule(self, command, ret=None):
         """

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -113,7 +113,7 @@ class Monitor(object):
         Stops a specific thread. Thread is removed from thread dictionary
         """
         if name in self.no_stop_threads:
-            self.logger.warning(f'Asked to stop thread {name}, but not permitted')
+            self.logger.error(f'Asked to stop thread {name}, but not permitted')
             return
         with self.lock:
             if name in self.threads:
@@ -121,7 +121,7 @@ class Monitor(object):
                 self.threads[name].join()
                 del self.threads[name]
             else:
-                self.logger.warning(f'Asked to stop thread {name}, but it isn\'t in the dict')
+                self.logger.error(f'Asked to stop thread {name}, but it isn\'t in the dict')
 
     def check_threads(self):
         """

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -12,12 +12,13 @@ class Monitor(object):
     A base monitor class
     """
 
-    def __init__(self, db=None, name=None, logger=None):
+    def __init__(self, db=None, name=None, logger=None, debug=False):
         """
         """
         self.db = db
         self.logger = logger
         self.name = name
+        self.debug = debug
         self.logger.debug(f'Monitor "{name}" constructing')
         self.event = threading.Event()
         # we use a lock to synchronize access to the thread dictionary

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -5,17 +5,18 @@ class ControlNode(Doberman.Node):
     """
     Another empty base class to handle different database access
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.control_target = kwargs['control_target']
         self.control_value = kwargs['control_value']
 
     def set_output(self, value, _force=False):
-        self.logger.debug(f'Setting {self.control_target} {self.control_value} to {value}')
+        self.logger.debug(f'Setting {self.control_target} {self.control_value} to {value}')  # TODO keep or remove?
         if not self.is_silent and not _force:
             self.pipeline.send_command(
-                    command=f'set {self.control_value} {value}',
-                    to=self.control_target)
+                command=f'set {self.control_value} {value}',
+                to=self.control_target)
 
     def on_error_do_this(self):
         if (v := self.config.get('default_output')) is not None:
@@ -27,6 +28,7 @@ class DigitalControlNode(ControlNode):
     A generalized node to handle digital output. The logic is assumed to be
     upstream.
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.one_input = kwargs.get('one_input', False)
@@ -36,10 +38,8 @@ class DigitalControlNode(ControlNode):
             self.set_output(package[self.input_var])
         else:
             if package[self.input_var[0]]:
-                self.logger.info(f'{self.name}: opening')
                 self.set_output(1)
             elif package[self.input_var[1]]:
-                self.logger.info(f'{self.name}: closing')
                 self.set_output(0)
 
 
@@ -48,6 +48,7 @@ class AnalogControlNode(ControlNode):
     A generalized node to handle analog output. The logic is assumed to be
     upstream
     """
+
     def process(self, package):
         val = package[self.input_var]
         if (min_output := self.config.get('min_output')) is not None:
@@ -61,6 +62,7 @@ class PipelineControlNode(Doberman.Node):
     """
     Sometimes you want one pipeline to control another.
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.actions = kwargs['actions']
@@ -68,8 +70,8 @@ class PipelineControlNode(Doberman.Node):
     def process(self, package):
         for condition, actions in self.actions.items():
             if package.get(condition, False):
-               for action in actions:
-                   self.control_pipeline(*action)
+                for action in actions:
+                    self.control_pipeline(*action)
 
         if package.get('condition_test', False):
             # this one is mainly for testing
@@ -88,5 +90,4 @@ class PipelineControlNode(Doberman.Node):
             raise ValueError(f'Don\'t know what to do with pipeline {pipeline}')
         self.logger.debug(f"Sending {action} to {pipeline}")
         self.pipeline.send_command(command=f'pipelinectl_{action} {pipeline}',
-                to=target)
-
+                                   to=target)

--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -12,7 +12,7 @@ class ControlNode(Doberman.Node):
         self.control_value = kwargs['control_value']
 
     def set_output(self, value, _force=False):
-        self.logger.debug(f'Setting {self.control_target} {self.control_value} to {value}')  # TODO keep or remove?
+        self.logger.debug(f'Setting {self.control_target} {self.control_value} to {value}')
         if not self.is_silent and not _force:
             self.pipeline.send_command(
                 command=f'set {self.control_value} {value}',

--- a/Doberman/Database.py
+++ b/Doberman/Database.py
@@ -202,8 +202,7 @@ class Database(object):
 
     def get_pipelines(self, flavor):
         """
-        Generates a list of names of pipelines to start now. Called by
-        PipelineMonitors on startup
+        Generates a list of names of pipelines to start now. Called by PipelineMonitors on startup.
         :param flavor: which type of pipelines to select, should be one of "alarm", "control", "convert"
         :yields: string
         """

--- a/Doberman/Database.py
+++ b/Doberman/Database.py
@@ -203,7 +203,7 @@ class Database(object):
     def get_pipelines(self, flavor):
         """
         Generates a list of names of pipelines to start now. Called by
-        PipelineMonitors on startup.
+        PipelineMonitors on startup
         :param flavor: which type of pipelines to select, should be one of "alarm", "control", "convert"
         :yields: string
         """
@@ -230,8 +230,7 @@ class Database(object):
         """
         protocols = self.get_experiment_config('alarm', 'protocols')
         if len(protocols) < level:
-            self.logger.error(f'No message protocols for alarm level {level}! '
-                              'Defaulting to highest level defined')
+            self.logger.error(f'No message protocols for alarm level {level}! Defaulting to highest level defined')
             return protocols[-1]
         return protocols[level]
 
@@ -276,7 +275,7 @@ class Database(object):
                 try:
                     ret[p].append(doc[p])
                 except KeyError:
-                    self.logger.info(f"No {p} contact details for {doc['name']}")
+                    self.logger.warning(f"No {p} contact details for {doc['name']}")
         return ret
 
     def get_heartbeat(self, device=None):
@@ -390,21 +389,6 @@ class Database(object):
             except Exception as e:
                 self.logger.error(f'{type(e)}: {e}')
                 self.logger.error(r.content)
-
-    def send_value_to_pipelines(self, sensor, value, timestamp):
-        """
-        Send a recently recorded value to the pipeline monitors
-        :param sensor: string, the name of the sensor
-        :param value: float/int, the value
-        :param timestamp: float, the timestamp
-        :returns: None
-        """
-        for pl in ['pl_alarm', 'pl_control', 'pl_convert']:
-            self.log_command(
-                f'sensor_value {sensor} {timestamp} {value}',
-                to=pl,
-                issuer=None,
-                bypass_hypervisor=True)
 
     def get_current_status(self):
         """

--- a/Doberman/Database.py
+++ b/Doberman/Database.py
@@ -274,7 +274,7 @@ class Database(object):
                 try:
                     ret[p].append(doc[p])
                 except KeyError:
-                    self.logger.warning(f"No {p} contact details for {doc['name']}")
+                    self.logger.error(f"No {p} contact details for {doc['name']}")
         return ret
 
     def get_heartbeat(self, device=None):

--- a/Doberman/DeviceMonitor.py
+++ b/Doberman/DeviceMonitor.py
@@ -21,7 +21,7 @@ class DeviceMonitor(Doberman.Monitor):
                       period=self.db.get_experiment_config(name='hypervisor', field='period'), _no_stop=True)
 
     def start_sensor(self, sensor_name):
-        self.logger.debug(f'Constructing {sensor_name}')
+        self.logger.info(f'Constructing {sensor_name}')
         sensor_doc = self.db.get_sensor_setting(sensor_name)
         kwargs = {'sensor_name': sensor_name, 'db': self.db,
                   'logger': Doberman.utils.get_child_logger(sensor_name, self.db, self.logger),
@@ -32,7 +32,7 @@ class DeviceMonitor(Doberman.Monitor):
                 # the "secondary" multi-sensors store the name of the base
                 sensor = Doberman.MultiSensor(**kwargs)
             else:
-                self.logger.debug(f'Not constructing {sensor_name} because it isn\'t the multi primary')
+                self.logger.info(f'Not constructing {sensor_name} because it isn\'t the multi primary')
                 return
         else:
             sensor = Doberman.Sensor(**kwargs)
@@ -41,19 +41,19 @@ class DeviceMonitor(Doberman.Monitor):
     def shutdown(self):
         if self.device is None:
             return
-        self.logger.debug('Stopping device')
+        self.logger.info('Stopping device')
         self.device.event.set()
         self.device.close()
         self.device = None
         return
 
     def open_device(self, reopen=False):
-        self.logger.debug('Connecting to device')
+        self.logger.info('Connecting to device')
         if self.device is not None and not reopen:
-            self.logger.debug('Already connected!')
+            self.logger.info('Already connected!')
             return
         if reopen:
-            self.logger.debug('Attempting reconnect')
+            self.logger.info('Attempting reconnect')
             self.device.event.set()
             self.device.close()
         try:

--- a/Doberman/DeviceMonitor.py
+++ b/Doberman/DeviceMonitor.py
@@ -11,7 +11,6 @@ class DeviceMonitor(Doberman.Monitor):
 
     def setup(self):
         plugin_dir = self.db.get_host_setting(field='plugin_dir')
-        self.logger.debug(plugin_dir)
         self.device_ctor = Doberman.utils.find_plugin(self.name, plugin_dir)
         self.device = None
         cfg_doc = self.db.get_device_setting(self.name)
@@ -42,7 +41,7 @@ class DeviceMonitor(Doberman.Monitor):
     def shutdown(self):
         if self.device is None:
             return
-        self.logger.info('Stopping device')
+        self.logger.debug('Stopping device')
         self.device.event.set()
         self.device.close()
         self.device = None
@@ -81,7 +80,7 @@ class DeviceMonitor(Doberman.Monitor):
         return self.db.get_experiment_config(name='hypervisor', field='period')
 
     def process_command(self, command):
-        self.logger.info(f"Found command '{command}'")
+        self.logger.info(f"Received command '{command}'")
         if command == 'reload sensors':
             self.reload_sensors()
         elif command == 'stop':

--- a/Doberman/Monitor.py
+++ b/Doberman/Monitor.py
@@ -16,6 +16,7 @@ def main(client):
     group.add_argument('--device', help='Start the specified device monitor')
     group.add_argument('--hypervisor', action='store_true', help='Start the hypervisor')
     group.add_argument('--status', action='store_true', help='Current status snapshot')
+    parser.add_argument('--debug', action='store_true', help='Set if DEBUG messages should be written to disk')
     args = parser.parse_args()
 
     k = 'DOBERMAN_EXPERIMENT_NAME'
@@ -56,7 +57,7 @@ def main(client):
     else:
         print('No action specified')
         return
-    logger = Doberman.utils.get_logger(kwargs['name'], db=db)
+    logger = Doberman.utils.get_logger(kwargs['name'], db=db, debug=args.debug)
     db.logger = logger
     kwargs['logger'] = logger
     my_logger = Doberman.utils.get_child_logger('monitor', db, logger)

--- a/Doberman/Monitor.py
+++ b/Doberman/Monitor.py
@@ -60,6 +60,7 @@ def main(client):
     logger = Doberman.utils.get_logger(kwargs['name'], db=db, debug=args.debug)
     db.logger = logger
     kwargs['logger'] = logger
+    kwargs['debug'] = args.debug
     my_logger = Doberman.utils.get_child_logger('monitor', db, logger)
     try:
         monitor = ctor(**kwargs)

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -8,7 +8,6 @@ class Node(object):
     """
 
     def __init__(self, pipeline=None, name=None, logger=None, **kwargs):
-        self.logger.debug(f'Constructing node {name}')
         self.pipeline = pipeline
         self.buffer = Doberman.utils.SortedBuffer(1)
         self.name = name
@@ -19,6 +18,8 @@ class Node(object):
         self.downstream_nodes = []
         self.config = {}
         self.is_silent = True
+        self.logger.debug(f'Constructing node {name}')
+
 
     def __del__(self):
         try:
@@ -39,6 +40,7 @@ class Node(object):
         pass
 
     def _process_base(self, is_silent):
+        self.logger.debug(f'{self.name} processing')
         self.is_silent = is_silent
         package = self.get_package()  # TODO discuss this wrt BufferNodes
         ret = self.process(package)
@@ -176,6 +178,7 @@ class InfluxSourceNode(SourceNode):
         except Exception as e:
             raise ValueError(f'Error parsing data: {response.content}')
         timestamp = int(timestamp)
+        self.logger.debug(f'{self.name} time {timestamp} value {val}')
         val = float(val)  # 53 bits of precision and we only ever have small integers
         return timestamp, val
 
@@ -188,6 +191,7 @@ class InfluxSourceNode(SourceNode):
                 # still nothing
                 raise ValueError(f'{self.name} didn\'t get a new value for {self.input_var}!')
         self.last_time = timestamp
+        self.logger.debug(f'{self.name} time {timestamp} value {val}')
         return {'time': timestamp * (10 ** -9), self.output_var: val}
 
 

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -18,7 +18,7 @@ class Node(object):
         self.downstream_nodes = []
         self.config = {}
         self.is_silent = True
-        self.logger.debug(f'Constructing node {name}')
+        self.logger.info(f'Constructing node {name}')
 
 
     def __del__(self):
@@ -55,7 +55,7 @@ class Node(object):
                 package[self.output_var] = ret
             except TypeError:
                 # Presumably a cryptic unhashable type error
-                self.logger.warning(f"Bad value ({self.output_var}) of output_var for node {self.name}")
+                self.logger.error(f"Bad value ({self.output_var}) of output_var for node {self.name}")
         self.send_downstream(package)
         self.post_process()
 

--- a/Doberman/Node.py
+++ b/Doberman/Node.py
@@ -8,6 +8,7 @@ class Node(object):
     """
 
     def __init__(self, pipeline=None, name=None, logger=None, **kwargs):
+        self.logger.debug(f'Constructing node {name}')
         self.pipeline = pipeline
         self.buffer = Doberman.utils.SortedBuffer(1)
         self.name = name
@@ -18,13 +19,12 @@ class Node(object):
         self.downstream_nodes = []
         self.config = {}
         self.is_silent = True
-        self.logger.debug(f'{name} constructor')
 
     def __del__(self):
         try:
             self.shutdown()
         except Exception as e:
-            self.logger.debug(f'{type(e)}: {e}')
+            self.logger.error(f'{type(e)}: {e}')
 
     def setup(self, **kwargs):
         """
@@ -39,7 +39,6 @@ class Node(object):
         pass
 
     def _process_base(self, is_silent):
-        self.logger.debug(f'{self.name} processing')
         self.is_silent = is_silent
         package = self.get_package()  # TODO discuss this wrt BufferNodes
         ret = self.process(package)
@@ -177,7 +176,6 @@ class InfluxSourceNode(SourceNode):
         except Exception as e:
             raise ValueError(f'Error parsing data: {response.content}')
         timestamp = int(timestamp)
-        self.logger.debug(f'{self.name} got timestamp {timestamp}')
         val = float(val)  # 53 bits of precision and we only ever have small integers
         return timestamp, val
 
@@ -190,7 +188,6 @@ class InfluxSourceNode(SourceNode):
                 # still nothing
                 raise ValueError(f'{self.name} didn\'t get a new value for {self.input_var}!')
         self.last_time = timestamp
-        self.logger.debug(f'{self.name} time {timestamp} value {val}')
         return {'time': timestamp * (10 ** -9), self.output_var: val}
 
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -160,7 +160,7 @@ class Pipeline(threading.Thread):
                                          f' Maybe you missed suffix "Node".')
                     except Exception as e:
                         self.logger.error(f'Caught a {type(e)} while building {kwargs["name"]}: {e}')
-                        self.logger.debug(f'Args: {node_kwargs}')
+                        self.logger.info(f'Args: {node_kwargs}')
                         raise
                     setup_kwargs = kwargs
                     fields = 'device topic subsystem description units alarm_level'.split()
@@ -185,7 +185,7 @@ class Pipeline(threading.Thread):
                         n.setup(**setup_kwargs)
                     except Exception as e:
                         self.logger.error(f'Caught a {type(e)} while setting up {n.name}: {e}')
-                        self.logger.debug(f'Args: {setup_kwargs}')
+                        self.logger.info(f'Args: {setup_kwargs}')
                         raise
                     graph[n.name] = n
 

--- a/Doberman/Pipeline.py
+++ b/Doberman/Pipeline.py
@@ -77,6 +77,7 @@ class Pipeline(threading.Thread):
             # reset
             self.silenced_at_level = -1
         timing = {}
+        self.logger.debug(f'Pipeline {self.name} cycle {self.cycles}')
         drift = 0
         for pl in self.subpipelines:
             for node in pl:

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -36,7 +36,7 @@ class PipelineMonitor(Doberman.Monitor):
             self.logger.error(f'No pipeline named {name} found')
             return
         if name in self.pipelines:
-            self.logger.warning(f'I already manage a pipeline called {name}')
+            self.logger.error(f'I already manage a pipeline called {name}')
             return
         self.logger.info(f'Starting pipeline {name}')
         self.db.set_pipeline_value(name, [('status', 'active')])
@@ -66,8 +66,7 @@ class PipelineMonitor(Doberman.Monitor):
         try:
             self.log_alarm(level, message)
         except Exception as e:
-            self.logger.error(f"Couldn't send level {level} alarm")
-            self.logger.info(f"{type(e)}: {e}")
+            self.logger.error(f"Got a {type(e)} while sending level {level} alarm: {e}")
 
     def process_command(self, command):
         try:
@@ -108,7 +107,6 @@ class PipelineMonitor(Doberman.Monitor):
                 self.logger.info(f'Sending level {level} test alarm')
                 self.testalarm(int(level))
             else:
-                self.logger.warning(f'I don\'t understand command "{command}"')
+                self.logger.error(f'I don\'t understand command "{command}"')
         except Exception as e:
-            self.logger.error(f'Received malformed command: {command}')
-            self.logger.info(f'{type(e)}: {e}')
+            self.logger.error(f'Got a {type(e)} while processing command "{command}": {e}')

--- a/Doberman/PipelineMonitor.py
+++ b/Doberman/PipelineMonitor.py
@@ -27,7 +27,7 @@ class PipelineMonitor(Doberman.Monitor):
             self.start_pipeline('test_pipeline')
 
     def shutdown(self):
-        self.logger.debug(f'{self.name} shutting down')
+        self.logger.info(f'{self.name} shutting down')
         for p in list(self.pipelines.keys()):
             self.stop_pipeline(p)
 
@@ -38,7 +38,7 @@ class PipelineMonitor(Doberman.Monitor):
         if name in self.pipelines:
             self.logger.warning(f'I already manage a pipeline called {name}')
             return
-        self.logger.debug(f'Starting pipeline {name}')
+        self.logger.info(f'Starting pipeline {name}')
         self.db.set_pipeline_value(name, [('status', 'active')])
         self.db.set_pipeline_value(name, [('silent_until', 0)])
         try:
@@ -56,7 +56,7 @@ class PipelineMonitor(Doberman.Monitor):
         return 0
 
     def stop_pipeline(self, name):
-        self.logger.debug(f'Stopping pipeline {name}')
+        self.logger.info(f'Stopping pipeline {name}')
         self.pipelines[name].stop()
         self.stop_thread(name)
         del self.pipelines[name]
@@ -67,7 +67,7 @@ class PipelineMonitor(Doberman.Monitor):
             self.log_alarm(level, message)
         except Exception as e:
             self.logger.error(f"Couldn't send level {level} alarm")
-            self.logger.debug(f"{type(e)}: {e}")
+            self.logger.info(f"{type(e)}: {e}")
 
     def process_command(self, command):
         try:
@@ -92,23 +92,23 @@ class PipelineMonitor(Doberman.Monitor):
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
-                    self.logger.debug(f'Silencing {name}')
+                    self.logger.info(f'Silencing {name}')
                     self.db.set_pipeline_value(name, [('silent_until', -1)])
             elif command.startswith('pipelinectl_active'):
                 _, name = command.split(' ')
                 if name not in self.pipelines:
                     self.logger.error(f'I don\'t control the "{name}" pipeline')
                 else:
-                    self.logger.debug(f'Activating {name}')
+                    self.logger.info(f'Activating {name}')
                     self.db.set_pipeline_value(name, [('silent_until', time.time())])
             elif command == 'stop':
                 self.sh.event.set()
             elif command.startswith('testalarm'):
                 _, level = command.split(' ')
-                self.logger.debug(f'Sending level {level} test alarm')
+                self.logger.info(f'Sending level {level} test alarm')
                 self.testalarm(int(level))
             else:
                 self.logger.warning(f'I don\'t understand command "{command}"')
         except Exception as e:
             self.logger.error(f'Received malformed command: {command}')
-            self.logger.debug(f'{type(e)}: {e}')
+            self.logger.info(f'{type(e)}: {e}')

--- a/Doberman/Sensor.py
+++ b/Doberman/Sensor.py
@@ -70,18 +70,18 @@ class Sensor(threading.Thread):
                 # timeout expired
                 failed = len(pkg) == 0
         if len(pkg) == 0 or failed:
-            self.logger.info(f'Didn\'t get anything from the device!')
+            self.logger.warning(f'Didn\'t get anything from the device!')
             return
         try:
             value = self.device_process(name=self.name, data=pkg['data'])
         except (ValueError, TypeError, ZeroDivisionError, UnicodeDecodeError, AttributeError) as e:
-            self.logger.debug(f'Got a {type(e)} while processing \'{pkg["data"]}\': {e}')
+            self.logger.warning(f'Got a {type(e)} while processing \'{pkg["data"]}\': {e}')
             value = None
         if value is not None:
             value = self.more_processing(value)
             self.send_downstream(value, pkg['time'])
         else:
-            self.logger.debug(f'Got None')
+            self.logger.warning(f'Got None')
         return
 
     def more_processing(self, value):

--- a/Doberman/Sensor.py
+++ b/Doberman/Sensor.py
@@ -29,7 +29,7 @@ class Sensor(threading.Thread):
         self.socket.connect(f'tcp://{hostname}:{ports["send"]}')
 
     def run(self):
-        self.logger.debug(f'Starting')
+        self.logger.info(f'Starting')
         while not self.event.is_set():
             loop_top = time.time()
             doc = self.db.get_sensor_setting(name=self.name)
@@ -37,7 +37,7 @@ class Sensor(threading.Thread):
             if doc['status'] == 'online':
                 self.do_one_measurement()
             self.event.wait(loop_top + self.readout_interval - time.time())
-        self.logger.debug(f'Returning')
+        self.logger.info(f'Returning')
 
     def setup(self, config_doc):
         """

--- a/Doberman/Sensor.py
+++ b/Doberman/Sensor.py
@@ -70,18 +70,18 @@ class Sensor(threading.Thread):
                 # timeout expired
                 failed = len(pkg) == 0
         if len(pkg) == 0 or failed:
-            self.logger.warning(f'Didn\'t get anything from the device!')
+            self.logger.error(f'Didn\'t get anything from the device!')
             return
         try:
             value = self.device_process(name=self.name, data=pkg['data'])
         except (ValueError, TypeError, ZeroDivisionError, UnicodeDecodeError, AttributeError) as e:
-            self.logger.warning(f'Got a {type(e)} while processing \'{pkg["data"]}\': {e}')
+            self.logger.error(f'Got a {type(e)} while processing \'{pkg["data"]}\': {e}')
             value = None
         if value is not None:
             value = self.more_processing(value)
             self.send_downstream(value, pkg['time'])
         else:
-            self.logger.warning(f'Got None')
+            self.logger.error(f'Got None')
         return
 
     def more_processing(self, value):

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -120,6 +120,7 @@ class Hypervisor(Doberman.Monitor):
             self.db.update_db('experiment_config', {'name': 'hypervisor'}, updates)
 
     def hypervise(self) -> None:
+        self.logger.debug('Hypervising')
         while not self.event.is_set():
             self.config = self.db.get_experiment_config('hypervisor')
             managed = self.config['processes']['managed']

--- a/Doberman/hypervisor.py
+++ b/Doberman/hypervisor.py
@@ -129,7 +129,7 @@ class Hypervisor(Doberman.Monitor):
             path = self.config['path']
             for pl in 'alarm control convert'.split():
                 if time.time() - self.last_pong.get(f'pl_{pl}', 100) > 30:
-                    self.logger.warrning(f'Failed to ping pl_{pl}, restarting it')
+                    self.logger.warning(f'Failed to ping pl_{pl}, restarting it')
                     if self.debug:
                         self.run_locally(f'cd {path} && ./start_process.sh --{pl} --debug')
                     else:

--- a/Doberman/utils.py
+++ b/Doberman/utils.py
@@ -12,11 +12,12 @@ import hashlib
 from math import floor, log10
 import itertools
 
-
 number_regex = r'[\-+]?[0-9]+(?:\.[0-9]+)?(?:[eE][\-+]?[0-9]+)?'
 
+
 def dtnow():
-    return datetime.datetime.now(tz=utc) # no timezone nonsense, now
+    return datetime.datetime.now(tz=utc)  # no timezone nonsense, now
+
 
 def find_plugin(name, path):
     """
@@ -36,7 +37,7 @@ def find_plugin(name, path):
         plugin_name = name.strip('0123456789')
         spec = importlib.machinery.PathFinder.find_spec(plugin_name, path)
     if spec is None:
-        plugin_name = name.rsplit('_',1)[0]
+        plugin_name = name.rsplit('_', 1)[0]
         spec = importlib.machinery.PathFinder.find_spec(plugin_name, path)
     if spec is None:
         raise FileNotFoundError('Could not find a device named %s in %s' % (name, path))
@@ -71,6 +72,7 @@ class DobermanLogger(logging.Handler):
     """
     A custom logging handler.
     """
+
     def __init__(self, db, name, output_handler):
         logging.Handler.__init__(self)
         self.db = db
@@ -91,11 +93,12 @@ class DobermanLogger(logging.Handler):
                 funcname=record.funcName,
                 lineno=record.lineno,
                 date=msg_datetime,
-                )
+            )
             self.db.insert_into_db(self.collection_name, rec)
 
     def format_message(self, when, level, func_name, lineno, msg):
         return f'{when.isoformat(sep=" ")} | {str(level).upper()} | {self.name} | {func_name} | {lineno} | {msg}'
+
 
 class OutputHandler(object):
     """
@@ -141,9 +144,10 @@ class OutputHandler(object):
                 # get pushed to disk, and we don't want this. If we do it too frequently it's slow
                 self.f.flush()
                 self.flush_cycle = 0
-    
+
     def get_logdir(self, date):
         return f'/global/logs/{self.experiment}/{date.year}/{date.month:02d}.{date.day:02d}'
+
 
 def get_logger(name, db):
     oh = OutputHandler(name, db.experiment_name)
@@ -152,6 +156,7 @@ def get_logger(name, db):
     logger.setLevel(logging.DEBUG)
     return logger
 
+
 def get_child_logger(name, db, main_logger):
     logger = logging.getLogger(name)
     if logger.hasHandlers():
@@ -159,6 +164,7 @@ def get_child_logger(name, db, main_logger):
     logger.addHandler(DobermanLogger(db, name, main_logger.handlers[0].oh))
     logger.setLevel(logging.DEBUG)
     return logger
+
 
 def make_hash(*args, hash_length=16):
     """
@@ -171,6 +177,7 @@ def make_hash(*args, hash_length=16):
     m = hashlib.sha256()
     map(lambda a: m.update(str(a).encode()), args)
     return m.hexdigest()[:hash_length]
+
 
 def sensible_sig_figs(value, lowlim, upplim, defaultsigfigs=3):
     """
@@ -192,6 +199,7 @@ class SortedBuffer(object):
     """
     A custom semi-fixed-width buffer that keeps itself sorted
     """
+
     def __init__(self, length=None):
         self._buf = []
         self.length = length
@@ -212,17 +220,17 @@ class SortedBuffer(object):
             else:
                 self._buf.append(obj)
         else:
-            idx = len(self._buf)//2
+            idx = len(self._buf) // 2
             for i in itertools.count(2):
-                lesser = self._buf[idx-1]['time'] if idx > 0 else -1
+                lesser = self._buf[idx - 1]['time'] if idx > 0 else -1
                 greater = self._buf[idx]['time'] if idx < len(self._buf) else LARGE_NUMBER
                 if lesser <= obj['time'] <= greater:
                     self._buf.insert(idx, obj)
                     break
                 elif obj['time'] > greater:
-                    idx += max(1, len(self._buf)>>i)
+                    idx += max(1, len(self._buf) >> i)
                 elif obj['time'] < lesser:
-                    idx -= max(1, len(self._buf)>>i)
+                    idx -= max(1, len(self._buf) >> i)
         if self.length is not None and len(self._buf) > self.length:
             self._buf = self._buf[-self.length:]
         return
@@ -249,4 +257,3 @@ class SortedBuffer(object):
 
     def __iter__(self):
         return self._buf.__iter__()
-

--- a/Doberman/utils.py
+++ b/Doberman/utils.py
@@ -108,7 +108,7 @@ class OutputHandler(object):
     so this is how I solve this problem.
     Files go to /global/logs/<experiment>/YYYY/MM.DD, folders being created as necessary.
     """
-    __slots__ = ('mutex', 'filename', 'experiment', 'f', 'today', 'flush_cycle')
+    __slots__ = ('mutex', 'filename', 'experiment', 'f', 'today', 'flush_cycle', 'debug')
 
     def __init__(self, name, experiment, debug=False):
         self.mutex = threading.Lock()

--- a/Doberman/utils.py
+++ b/Doberman/utils.py
@@ -156,6 +156,8 @@ def get_logger(name, db, debug=False):
     logger.addHandler(DobermanLogger(db, name, oh))
     if debug:
         logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
     return logger
 
 
@@ -166,6 +168,8 @@ def get_child_logger(name, db, main_logger):
     logger.addHandler(DobermanLogger(db, name, main_logger.handlers[0].oh))
     if main_logger.handlers[0].oh.debug:
         logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
     return logger
 
 

--- a/scripts/start_process.sh
+++ b/scripts/start_process.sh
@@ -1,43 +1,50 @@
 #!/bin/bash
 
-USAGE="Usage: $0 [--alarm] [--control] [--convert] [--device <device>] [--hypervisor]"
+USAGE="Usage: $0 [--alarm] [--control] [--convert] [--device <device>] [--hypervisor] [--debug]"
 folder="/global/software/doberman/Doberman"
 
 x=0
+debug_mode=false
 
-while [[ $1 =~ ^- && ! $1 == '--' ]]; do case $1 in
-  --alarm )
-    target="alarm"
-    screen_name="pl_alarm"
-    x=$((x+1))
-    ;;
-  --control )
-    target="control"
-    screen_name="pl_control"
-    x=$((x+1))
-    ;;
-  --convert )
-    target="convert"
-    screen_name="pl_convert"
-    x=$((x+1))
-    ;;
-  -d | --device )
-    shift
-    name=$1
-    target="device"
-    screen_name=$1
-    x=$((x+1))
-    ;;
-  --hypervisor )
-    target="hypervisor"
-    screen_name="hypervisor"
-    x=$((x+1))
-    ;;
-  * )
-    echo $USAGE
-    exit 1
-    ;;
-esac; shift; done
+while [[ $1 =~ ^- && ! $1 == '--' ]]; do
+  case $1 in
+    --alarm )
+      target="alarm"
+      screen_name="pl_alarm"
+      x=$((x+1))
+      ;;
+    --control )
+      target="control"
+      screen_name="pl_control"
+      x=$((x+1))
+      ;;
+    --convert )
+      target="convert"
+      screen_name="pl_convert"
+      x=$((x+1))
+      ;;
+    -d | --device )
+      shift
+      name=$1
+      target="device"
+      screen_name=$1
+      x=$((x+1))
+      ;;
+    --hypervisor )
+      target="hypervisor"
+      screen_name="hypervisor"
+      x=$((x+1))
+      ;;
+    --debug )
+      debug_mode=true
+      ;;
+    * )
+      echo $USAGE
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 if [[ $x != 1 ]]; then
   echo $USAGE
@@ -48,5 +55,11 @@ if [[ -n $(screen -ls | grep $screen_name ) ]]; then
   echo "Killing existing screen"
   screen -S $screen_name -X quit
 fi
-echo "cd $folder && ./Monitor.py --$target $name"
-screen -S $screen_name -dm /bin/bash -c "cd $folder && ./Monitor.py --$target $name"
+
+command="cd $folder && ./Monitor.py --$target $name"
+if [ "$debug_mode" = true ]; then
+  command+=" --debug"
+fi
+
+echo "$command"
+screen -S $screen_name -dm /bin/bash -c "$command"


### PR DESCRIPTION
Logging is quite inconsistent and I personally never find what I want at the place I expect it. Some rules that make sense to me:

- Avoid repeating DEBUG-level messages. They are great during development but at the current state they clog the debug logs and are not used anymore.
- Use WARNING for things that are expected but should be in the website logs. Like 'alarm for sensor XXX', 'sending SMS to ...'
- Use WARNING also for things that are somewhat unexpected but don't hinder Doberman's operation too much. E.g. 'didn't get a value from device XXX' which could be a one time thing or more regular -> Good to see these on the website
- Use ERROR for (most) caught exceptions. Here something just did not work as it should. A device/pipeline didn't get started, an alarm message could not be sent, ...

Open for debate:
- Use CRITICAL never?
- difference INFO and DEBUG? Maybe it also makes sense to keep the `self.logger.debug` but not log them unless Doberman is explicitly started in DEBUG mode...