### PR TITLE
Fix test pipeline

### DIFF
--- a/Doberman/ControlNode.py
+++ b/Doberman/ControlNode.py
@@ -71,14 +71,11 @@ class PipelineControlNode(Doberman.Node):
                for action in actions:
                    self.control_pipeline(*action)
 
-        if package.get('condition_test', False):
-            # this one is mainly for testing
-            self.control_pipeline('stop', self.pipeline.name)
 
     def control_pipeline(self, action, pipeline):
         if self.is_silent:
             return
-        if pipeline.startswith('control'):
+        if pipeline.startswith('control') or pipeline.startswith('test'):
             target = 'pl_control'
         elif pipeline.startswith('alarm'):
             target = 'pl_alarm'

--- a/scripts/make_test_pl.py
+++ b/scripts/make_test_pl.py
@@ -59,17 +59,16 @@ pl = {
             {
                 'type': 'EvalNode',
                 'operation': 'True',
-                'output_var': 'condition_test',
+                'output_var': 'condition',
                 'input_var': [SENSOR_INPUT],
                 'name': 'eval',
                 'upstream': ['integral']
             },
             {
-                'type': 'PipelineControl',
+                'type': 'PipelineControlNode',
                 'name': 'end',
-                'input_var': '',
-                'control_target': '',
-                'control_value': '',
+                'input_var': 'condition_test',
+                'actions': {'condition': ['stop test_pipeline']}
                 'upstream': ['eval']
             }
         ],

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,5 @@ setuptools.setup(name='Doberman',
                  description='Doberman slow control',
                  python_requires='>=3.7',
                  packages=setuptools.find_packages(),
-                 #install_requires=[
-                 #    pyserial,
-                 #    pymongo,
-                 #    numpy,
-                 #    influxdb,
-                 #    psutil,
-                 #    requests,
-                 #    python-dateutil,
-                 #    ]
+                 install_requires=requires
                  )


### PR DESCRIPTION
There was a small problem with the test_pipeline that creates itself on start-up. Like this, it now uses the generic PipelineControlNode instead of some hardcoded stuff. 