### PR TITLE
Alarm node updates

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -263,8 +263,8 @@ class TimeSinceAlarmNode(AlarmNode):
 
     def process(self, package):
         value = int(package[self.input_var])
-        alarm_value = self.config.get('alarm_value')
-        tmax = self.config.get('max_duration')
+        alarm_value = int(self.config.get('alarm_value'))
+        tmax = int(self.config.get('max_duration'))
         if value == alarm_value:
             now = time.time()
             self.time_since += (now - self.last_checked)
@@ -273,4 +273,5 @@ class TimeSinceAlarmNode(AlarmNode):
             self.time_since = 0
             self.last_checked = time.time()
         if self.time_since > tmax:
+            self.config['alarm_level'] = int(self.config['alarm_level'])
             self.log_alarm(f'Alarm for {self.description}: value is at {alarm_value} for more than {tmax} seconds.')

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -209,8 +209,9 @@ class IntegerAlarmNode(Doberman.BufferNode, AlarmNode):
         super().load_config(doc)
 
     def process(self, packages):
-        values = [p[self.input_var] for p in packages]
-        bad_values = list(self.config['alarm_values'].keys())
+        values = [int(p[self.input_var]) for p in packages]
+        bad_values = [int(bv) for bv in list(self.config['alarm_values'].keys())]
+
         is_ok = [v not in bad_values for v in values]
         if any(is_ok):
             # at least one value is in an acceptable range

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -6,6 +6,7 @@ class AlarmNode(Doberman.Node):
     """
     An empty base class to handle database access
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.description = kwargs['description']
@@ -30,13 +31,13 @@ class AlarmNode(Doberman.Node):
         total_level = self.config['alarm_level'] + self.escalation_level
         if self.messages_this_level > self.escalation_config[total_level]:
             self.logger.warning((f'{self.name} at level {self.config["alarm_level"]}/{self.escalation_level} '
-                f'for {self.messages_this_level} messages, time to escalate (hash {self.hash})'))
-            max_total_level = len(self.escalation_config)-1
+                                 f'for {self.messages_this_level} messages, time to escalate (hash {self.hash})'))
+            max_total_level = len(self.escalation_config) - 1
             self.escalation_level = min(max_total_level - self.config['alarm_level'], self.escalation_level + 1)
             self.messages_this_level = 0  # reset count so we don't escalate again immediately
         else:
             self.logger.info((f'{self.name} at level {self.config["alarm_level"]}/{self.escalation_level} '
-                    f'for {self.messages_this_level} messages, need {self.escalation_config[total_level]} to escalate'))
+                              f'for {self.messages_this_level} messages, need {self.escalation_config[total_level]} to escalate'))
 
     def reset_alarm(self):
         """
@@ -76,10 +77,12 @@ class AlarmNode(Doberman.Node):
         else:
             self.logger.debug(msg)
 
+
 class CheckRemoteHeartbeatNode(Doberman.Node):
     """
     A node that checks if a remote heartbeat has been updated recently and otherwise sends alarms.
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self._log_alarm = kwargs['log_alarm']
@@ -93,7 +96,7 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             try:
                 self._log_alarm(message=msg,
                                 pipeline=self.pipeline.name,
-                                prot_rec_dict=prd,)
+                                prot_rec_dict=prd, )
                 # self-silence if the message was successfully sent
                 self.pipeline.silence_for(int(self.config.get('silence_duration', 300)), -1)
             except Exception as e:
@@ -110,19 +113,21 @@ class CheckRemoteHeartbeatNode(Doberman.Node):
             timestamp, numbers_string = f.read().split('\n', maxsplit=1)
             numbers = numbers_string.strip().split(',')
             dt = time.time() - int(timestamp)
-            if dt > int(self.config.get('max_delay_sms', 3*60)): # default 3 minutes for sms
-                msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {round(dt/60)} minutes."
+            if dt > int(self.config.get('max_delay_sms', 3 * 60)):  # default 3 minutes for sms
+                msg = f"The hypervisor of {experiment_name} hasn't had a heartbeat for {round(dt / 60)} minutes."
                 prd = {'sms': numbers}
-                if dt > int(self.config.get('max_delay_phone', 10*60)): # and 10 minutes for phone + sms
+                if dt > int(self.config.get('max_delay_phone', 10 * 60)):  # and 10 minutes for phone + sms
                     prd['phone'] = numbers
                 self.log_alarm(msg, prd)
             else:
                 self.logger.debug(f'Last remote heartbeat from {experiment_name} was {int(dt)} seconds ago.')
 
+
 class DeviceRespondingBase(AlarmNode):
     """
     A base class to check if sensors are returning data
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.accept_old = True
@@ -153,6 +158,7 @@ class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
     Then endpoints of the interval are assumed to represent acceptable values, only
     values outside are considered 'alarm'.
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.strict = True
@@ -187,20 +193,34 @@ class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
             self.log_alarm(msg, packages[-1]['time'])
 
 
-class IntegerAlarmNode(AlarmNode):
+class IntegerAlarmNode(Doberman.BufferNode, AlarmNode):
     """
     Integer status quantities are a fundamentally different thing from physical values.
     It makes sense to process them differently. The thresholds should be stored as [value, message] pairs.
     """
+
     def setup(self, **kwargs):
         super().setup(**kwargs)
-        self.sensor_config_needed += ['alarm_values', 'alarm_level']
+        self.strict = True
+        self.sensor_config_needed += ['alarm_values', 'alarm_level', 'alarm_recurrence']
 
-    def process(self, package):
-        value = int(package[self.input_var])
-        for v, msg in self.config['alarm_values'].items():
-            if value == int(v):
-                self.log_alarm(f'Alarm for {self.description}: {msg}')
+    def load_config(self, doc):
+        doc.update(length=doc['alarm_recurrence'])
+        super().load_config(doc)
+
+    def process(self, packages):
+        values = [p[self.input_var] for p in packages]
+        bad_values = list(self.config['alarm_values'].keys())
+        is_ok = [v not in bad_values for v in values]
+        if any(is_ok):
+            # at least one value is in an acceptable range
+            pass
+        elif all(is_ok):
+            # we're no longer in an alarmed state so reset the hash
+            self.reset_alarm()
+        else:
+            for v in set(values):
+                self.log_alarm(f'Alarm for {self.description}: {self.config["alarm_values"][str(v)]}')
                 break
 
 
@@ -216,6 +236,7 @@ class BitmaskIntegerAlarmNode(AlarmNode):
     (meaning bit[0]=1 and bit[1]=0). Both bitmask and value are assumed to be in **hex**
     and will be integer-cast before use (mask = int(mask, base=16))
     """
+
     def process(self, package):
         value = int(package[self.input_var])
         alarm_msg = []
@@ -226,4 +247,3 @@ class BitmaskIntegerAlarmNode(AlarmNode):
                 alarm_msg.append(msg)
         if len(alarm_msg):
             self.log_alarm(f'Alarm for {self.description}: {",".join(alarm_msg)}')
-

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -254,6 +254,15 @@ class TimeSinceAlarmNode(AlarmNode):
     """
     Checks whether a measurement was at the alarm_value for more than the max_duration.
     Useful to answer questions like 'Has this valve been open for too long?'
+
+    Setup params:
+    None
+
+    Runtime params:
+    :param alarm_value: value that should trigger the alarm
+    :param max_duration: maximal duration for which the value is allowed to be at alarm_value before logging an alarm
+    :param alarm_level: base level of the alarm (note we don't take the one from the sensor since this is reserved for
+                        the IntegerAlarmNode (SimpleAlarmNode)).
     """
 
     def setup(self, **kwargs):
@@ -274,4 +283,5 @@ class TimeSinceAlarmNode(AlarmNode):
             self.last_checked = time.time()
         if self.time_since > tmax:
             self.config['alarm_level'] = int(self.config['alarm_level'])
-            self.log_alarm(f'Alarm for {self.description}: value is at {alarm_value} for more than {tmax} seconds.')
+            self.log_alarm(f'Alarm for {self.description}: value is at {alarm_value} for more than '
+                           f'{int(self.time_since)} seconds.')


### PR DESCRIPTION
- Makes IntegerAlarmNode a BufferNode so it doesn't automatically trigger after one value but after the recurrence defined in sensor settings (i.e. just like a simple alarm). Solves #235 .
- Adds `TimeSinceAlarmNode` that triggers once a sensor has been measuring the `alarm_value` for longer than the `max_duration`. It only really makes sense for integer sensors (e.g. 'this valve has been open for too long!'), but I don't see a use-case for a 'time since out of threshold'-alarm. Or put in another way, this would be the same as a SimpleAlarm with the right recurrence setting, or am missing something? Solves #236 

- [ ] Update wiki before merging
 