### PR TITLE
Do not set monitor active on failure

### DIFF
--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -28,7 +28,7 @@ class Monitor(object):
         self.restart_info = {}
         self.no_stop_threads = set()
         self.sh = Doberman.utils.SignalHandler(self.logger, self.event)
-        self.db.notify_hypervisor(active=self.name)
+
         self.logger.debug('Child setup starting')
         self.setup()
         self.logger.debug('Child setup completed')

--- a/Doberman/Monitor.py
+++ b/Doberman/Monitor.py
@@ -62,6 +62,7 @@ def main(client):
     my_logger = Doberman.utils.get_child_logger('monitor', db, logger)
     try:
         monitor = ctor(**kwargs)
+        db.notify_hypervisor(active=kwargs["name"])
     except Exception as e:
         my_logger.critical(f'Caught a {type(e)} while constructing {kwargs["name"]}: {e}')
         return


### PR DESCRIPTION
This causes a very annoying bug, where you 'activate' a device e.g. via the website and it doesn't start properly (i.e. you run into the Exception in line 65/66 of Monitor.py), it makes it impossible to deactivate it again, unless you do it via MongoDB.

With this fix the device just won't activate and together with [unmanage_inactive](https://github.com/AG-Schumann/doberview2/pull/76), you can then just unmanage the device once you see it failed to start so it doesn't try to restart it over and over again.