### PR TITLE
Fix KeyError in DeviceRespondingNodes

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -160,7 +160,7 @@ class DeviceRespondingBase(AlarmNode):
     def setup(self, **kwargs):
         super().setup(**kwargs)
         self.accept_old = True
-        self.sensor_config_needed += ['alarm_recurrence']
+        self.sensor_config_needed += ['alarm_level']
 
     def process(self, package):
         if (dt := ((now := time.time()) - package['time'])) > self.config['readout_interval'] + self.max_reading_delay:


### PR DESCRIPTION
The device responding nodes are not working. When they [log the alarm](https://github.com/AG-Schumann/Doberman/blob/master/Doberman/AlarmNode.py#L54),` config['alarm_level']` throws a `KeyError` . This need to be fixed ASAP.