### PR TITLE
Hypervisor refactor, Unknown hash fix

### DIFF
--- a/Doberman/utils.py
+++ b/Doberman/utils.py
@@ -182,7 +182,8 @@ def make_hash(*args, hash_length=16):
     :returns: string
     """
     m = hashlib.sha256()
-    map(lambda a: m.update(str(a).encode()), args)
+    for a in args:
+        m.update(str(a).encode())
     return m.hexdigest()[:hash_length]
 
 


### PR DESCRIPTION
This looks more than it is and is mostly a restructuring of the code. However, it fixes some annoying bugs that arose due to the wrong understanding of the map-function in previous commits (i.e. using map without converting its result to a list or iterating over it does not execute the function calls).

- L30: Fixed so localhost's startup sequence is executed. Don't have that in our setups so we missed it.
- L22ff: Less clunky setting of --debug flag.
- L83ff: Timeouts in shutdown sequence just to be sure.
- L114: Fix bug in hypervisor's heartbeat update. Apparently,  this heartbeat is not used anywhere so this wasn't caught earlier.
- L160ff: Just less clunky code
- L251ff: Created helper functions like `calculate_timeout_ms`, `handle_incoming_message`, `process_external_command`, `process_acknowledgement`, and `remove_stale_acknowledgements` to break down the logic into smaller, more manageable pieces. Especially, `remove_stale_acknowledgements` now works as intended.
- utils.py, make_hash: Hashes are now actually updated to be unique. This should fix the problem of getting many 'Unknown hash from ... ' error logs. 
