### PR TITLE
Make reset_alarm work

### DIFF
--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -29,15 +29,16 @@ class AlarmNode(Doberman.Node):
         if self.hash is None:
             self.logger.error('How are you escalating if there is no active alarm?')
             return
-        total_level = self.config['alarm_level'] + self.escalation_level
-        if self.messages_this_level > self.escalation_config[total_level]:
-            self.logger.warning((f'{self.name} at level {self.config["alarm_level"]}/{self.escalation_level} '
+        base_level = self.config['alarm_level']
+        total_level = base_level + self.escalation_level
+        if self.messages_this_level >= self.escalation_config[total_level]:
+            self.logger.warning((f'{self.name} at level {base_level}+{self.escalation_level} '
                                  f'for {self.messages_this_level} messages, time to escalate (hash {self.hash})'))
             max_total_level = len(self.escalation_config) - 1
-            self.escalation_level = min(max_total_level - self.config['alarm_level'], self.escalation_level + 1)
+            self.escalation_level = min(max_total_level - base_level, self.escalation_level + 1)
             self.messages_this_level = 0  # reset count so we don't escalate again immediately
         else:
-            self.logger.warning((f'{self.name} at level {self.config["alarm_level"]}/{self.escalation_level} '
+            self.logger.warning((f'{self.name} at level {base_level}+{self.escalation_level} '
                                  f'for {self.messages_this_level} messages, need {self.escalation_config[total_level]} '
                                  f'to escalate'))
     def reset_alarm(self):

--- a/Doberman/AlarmNode.py
+++ b/Doberman/AlarmNode.py
@@ -46,7 +46,7 @@ class AlarmNode(Doberman.Node):
         """
         self.set_sensor_setting(self.input_var, 'alarm_is_triggered', False)
         if self.hash is not None:
-            self.logger.info(f'{self.name} resetting alarm {self.hash}')
+            self.logger.info(f'{self.name} resetting alarm (hash {self.hash})')
             self.hash = None
             self.messages_this_level = 0
         self.escalation_level = 0
@@ -201,12 +201,12 @@ class SimpleAlarmNode(Doberman.BufferNode, AlarmNode):
         values = [p[self.input_var] for p in packages]
         low, high = self.config['alarm_thresholds']
         is_ok = [low <= v <= high for v in values]
-        if any(is_ok):
-            # at least one value is in an acceptable range
-            pass
-        elif all(is_ok):
+        if all(is_ok):
             # we're no longer in an alarmed state so reset the hash
             self.reset_alarm()
+        elif any(is_ok):
+            # at least one value is in an acceptable range
+            pass
         else:
             msg = f'Alarm for {self.description}. '
             try:
@@ -240,14 +240,13 @@ class IntegerAlarmNode(Doberman.BufferNode, AlarmNode):
     def process(self, packages):
         values = [int(p[self.input_var]) for p in packages]
         bad_values = [int(bv) for bv in list(self.config['alarm_values'].keys())]
-
         is_ok = [v not in bad_values for v in values]
-        if any(is_ok):
-            # at least one value is in an acceptable range
-            pass
-        elif all(is_ok):
+        if all(is_ok):
             # we're no longer in an alarmed state so reset the hash
             self.reset_alarm()
+        elif any(is_ok):
+            # at least one value is in an acceptable range
+            pass
         else:
             for v in set(values):
                 self.log_alarm(f'Alarm for {self.description}: {self.config["alarm_values"][str(v)]}')

--- a/Doberman/BaseMonitor.py
+++ b/Doberman/BaseMonitor.py
@@ -47,7 +47,7 @@ class Monitor(object):
         """
         self.event.set()
         self.shutdown()
-        pop = []
+        threads_to_pop = []
         with self.lock:
             for t in self.threads.values():
                 # set the events all here because join() blocks
@@ -59,8 +59,9 @@ class Monitor(object):
                 except Exception as e:
                     self.logger.error(f'Can\'t close {n}-thread. {e}')
                 else:
-                    pop.append(n)
-        map(self.threads.pop, pop)
+                    threads_to_pop.append(n)
+        for p in threads_to_pop:
+            self.threads.pop(p)
         self.db.notify_hypervisor(inactive=self.name)
 
     def register(self, name, obj, period=None, _no_stop=False, **kwargs):


### PR DESCRIPTION
This bug became only apparent once we fixed the hashing system, I guess.

**Intended function:** 
- if all values in the AlarmNode's buffer are bad -> Send alarm
- if any value is okay (1 or more) -> do nothing
- if all values in the buffer are okay -> Reset the escalation level. 

The way it was coded, the last condition was never reached (because `pass` ends the if-elif-else statement)


Also, I think the escalation happened one message too late. Depends a bit on the wording. 

Also there is one more map()-function bug fixed in the Monitor shutdown sequence.